### PR TITLE
Add legal benchmark extraction receipts

### DIFF
--- a/crates/psionic-eval/examples/legal_benchmark_extract_slice.rs
+++ b/crates/psionic-eval/examples/legal_benchmark_extract_slice.rs
@@ -1,0 +1,84 @@
+#![allow(clippy::print_stdout)]
+
+use std::collections::BTreeMap;
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+use psionic_eval::{
+    ArtifactExtractionPolicy, ArtifactExtractorRegistry, ExtractionFailureKind, scan_harvey_corpus,
+};
+use serde::Serialize;
+
+#[derive(Debug, Serialize)]
+struct SliceExtractionSummary {
+    tasks_root: String,
+    upstream_commit: String,
+    task_limit: usize,
+    task_count_scanned: usize,
+    source_artifact_count: usize,
+    extracted_count: usize,
+    structured_failure_count: usize,
+    failures_by_kind: BTreeMap<String, usize>,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut args = env::args().skip(1);
+    let tasks_root = args.next().map(PathBuf::from).ok_or_else(|| {
+        "usage: legal_benchmark_extract_slice <harvey_tasks_root> <upstream_commit> [task_limit]"
+            .to_string()
+    })?;
+    let upstream_commit = args.next().ok_or_else(|| {
+        "usage: legal_benchmark_extract_slice <harvey_tasks_root> <upstream_commit> [task_limit]"
+            .to_string()
+    })?;
+    let task_limit = args
+        .next()
+        .map(|value| value.parse::<usize>())
+        .transpose()?
+        .unwrap_or(20);
+
+    let scan = scan_harvey_corpus(tasks_root.as_path(), upstream_commit.clone())?;
+    let registry = ArtifactExtractorRegistry::default();
+    let policy = ArtifactExtractionPolicy::default();
+
+    let mut source_artifact_count = 0usize;
+    let mut extracted_count = 0usize;
+    let mut structured_failure_count = 0usize;
+    let mut failures_by_kind = BTreeMap::new();
+
+    for task in scan.tasks.iter().take(task_limit) {
+        for source_artifact in &task.source_artifacts {
+            source_artifact_count += 1;
+            let source_path = tasks_root.join(source_artifact.relative_path.as_str());
+            let bytes = fs::read(source_path)?;
+            let result = registry.extract(source_artifact, bytes.as_slice(), &policy);
+            match result.receipt.failure_kind {
+                Some(kind) => {
+                    structured_failure_count += 1;
+                    *failures_by_kind
+                        .entry(failure_kind_label(kind))
+                        .or_insert(0) += 1;
+                }
+                None => extracted_count += 1,
+            }
+        }
+    }
+
+    let summary = SliceExtractionSummary {
+        tasks_root: tasks_root.display().to_string(),
+        upstream_commit,
+        task_limit,
+        task_count_scanned: scan.tasks.len().min(task_limit),
+        source_artifact_count,
+        extracted_count,
+        structured_failure_count,
+        failures_by_kind,
+    };
+    println!("{}", serde_json::to_string_pretty(&summary)?);
+    Ok(())
+}
+
+fn failure_kind_label(kind: ExtractionFailureKind) -> String {
+    format!("{kind:?}")
+}

--- a/crates/psionic-eval/src/legal_benchmark.rs
+++ b/crates/psionic-eval/src/legal_benchmark.rs
@@ -393,6 +393,9 @@ pub struct RunRecord {
     pub tool_calls: Vec<ToolCallRecord>,
     /// Aggregate run metrics.
     pub metrics: RunMetrics,
+    /// Extraction receipt ids or hashes retained by this run.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extraction_receipt_refs: Vec<String>,
     /// Additional owned metadata.
     #[serde(default, skip_serializing_if = "Metadata::is_empty")]
     pub metadata: Metadata,
@@ -561,6 +564,9 @@ pub struct ScoreReport {
     pub criterion_results: Vec<CriterionResult>,
     /// Run metrics copied into the report.
     pub metrics: RunMetrics,
+    /// Extraction receipt ids or hashes considered by the scorer.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extraction_receipt_refs: Vec<String>,
     /// Additional owned metadata.
     #[serde(default, skip_serializing_if = "Metadata::is_empty")]
     pub metadata: Metadata,

--- a/crates/psionic-eval/src/legal_benchmark_extraction.rs
+++ b/crates/psionic-eval/src/legal_benchmark_extraction.rs
@@ -1,0 +1,908 @@
+//! Document extraction contracts for legal-agent benchmarks.
+//!
+//! The day-one implementation keeps the Rust-owned interface, receipts, and
+//! native text extraction in this crate. Heavy Office/PDF/email extraction is
+//! represented as pinned sandboxed external adapter specs so runner work can
+//! attach real command execution without changing downstream receipt schemas.
+
+use std::collections::BTreeMap;
+use std::path::Path;
+use std::time::Instant;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+
+use crate::{ArtifactKind, Metadata, SourceArtifact, stable_json_digest};
+
+pub const LEGAL_BENCHMARK_EXTRACTION_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtractionOutputFormat {
+    PlainText,
+    Markdown,
+    JsonText,
+    StructuredJson,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ArtifactExtractionPolicy {
+    pub schema_version: u16,
+    pub policy_id: String,
+    pub max_input_bytes: u64,
+    pub output_format: ExtractionOutputFormat,
+    pub external_tools_allowed: bool,
+    pub sandbox_required: bool,
+    pub fail_on_warning: bool,
+    pub extractor_allowlist: Vec<String>,
+    #[serde(default, skip_serializing_if = "Metadata::is_empty")]
+    pub metadata: Metadata,
+}
+
+impl Default for ArtifactExtractionPolicy {
+    fn default() -> Self {
+        Self {
+            schema_version: LEGAL_BENCHMARK_EXTRACTION_SCHEMA_VERSION,
+            policy_id: "legal_benchmark.extraction.default.v1".to_string(),
+            max_input_bytes: 64 * 1024 * 1024,
+            output_format: ExtractionOutputFormat::PlainText,
+            external_tools_allowed: true,
+            sandbox_required: true,
+            fail_on_warning: false,
+            extractor_allowlist: Vec::new(),
+            metadata: Metadata::new(),
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtractionFailureKind {
+    UnsupportedArtifact,
+    InputTooLarge,
+    DecodeError,
+    JsonParseError,
+    PolicyDenied,
+    ExternalToolUnavailable,
+    ExternalCommandFailed,
+    SandboxUnavailable,
+    Timeout,
+    IoError,
+    InternalError,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ExtractionWarning {
+    pub warning_code: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Metadata::is_empty")]
+    pub metadata: Metadata,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ExtractionCoverage {
+    pub input_byte_count: u64,
+    pub output_byte_count: u64,
+    pub output_char_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub page_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pages_extracted: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sheet_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sheets_extracted: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_part_count: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message_parts_extracted: Option<u32>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExtractionReceipt {
+    pub schema_version: u16,
+    pub receipt_id: String,
+    pub source_artifact_id: String,
+    pub source_artifact_hash: String,
+    pub source_artifact_path: String,
+    pub input_media_type: String,
+    pub input_byte_size: u64,
+    pub extractor_name: String,
+    pub extractor_version: String,
+    pub command_or_crate_version: String,
+    pub output_format: ExtractionOutputFormat,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_artifact_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_hash: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_byte_size: Option<u64>,
+    pub coverage: ExtractionCoverage,
+    pub warnings: Vec<ExtractionWarning>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_kind: Option<ExtractionFailureKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sandbox_receipt_ref: Option<String>,
+    pub elapsed_ms: u64,
+    #[serde(default, skip_serializing_if = "Metadata::is_empty")]
+    pub metadata: Metadata,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ExtractedArtifact {
+    pub artifact: SourceArtifact,
+    pub text: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ArtifactExtractionResult {
+    pub receipt: ExtractionReceipt,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extracted_artifact: Option<ExtractedArtifact>,
+}
+
+pub trait ArtifactExtractor {
+    fn extractor_name(&self) -> &'static str;
+    fn extractor_version(&self) -> &'static str;
+    fn command_or_crate_version(&self) -> &'static str;
+    fn supports(&self, artifact: &SourceArtifact) -> bool;
+
+    fn extract(
+        &self,
+        artifact: &SourceArtifact,
+        bytes: &[u8],
+        policy: &ArtifactExtractionPolicy,
+    ) -> ArtifactExtractionResult;
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct NativeTextArtifactExtractor;
+
+impl ArtifactExtractor for NativeTextArtifactExtractor {
+    fn extractor_name(&self) -> &'static str {
+        "psionic.native_text"
+    }
+
+    fn extractor_version(&self) -> &'static str {
+        "1.0.0"
+    }
+
+    fn command_or_crate_version(&self) -> &'static str {
+        "std::str+serde_json"
+    }
+
+    fn supports(&self, artifact: &SourceArtifact) -> bool {
+        is_native_text_artifact(artifact)
+    }
+
+    fn extract(
+        &self,
+        artifact: &SourceArtifact,
+        bytes: &[u8],
+        policy: &ArtifactExtractionPolicy,
+    ) -> ArtifactExtractionResult {
+        let started = Instant::now();
+        if !extractor_allowed(self.extractor_name(), policy) {
+            return failure_result(
+                artifact,
+                self.extractor_name(),
+                self.extractor_version(),
+                self.command_or_crate_version(),
+                policy.output_format,
+                bytes.len(),
+                started,
+                ExtractionFailureKind::PolicyDenied,
+                "extractor is not allowed by extraction policy",
+                Vec::new(),
+            );
+        }
+        if bytes.len() > usize::try_from(policy.max_input_bytes).unwrap_or(usize::MAX) {
+            return failure_result(
+                artifact,
+                self.extractor_name(),
+                self.extractor_version(),
+                self.command_or_crate_version(),
+                policy.output_format,
+                bytes.len(),
+                started,
+                ExtractionFailureKind::InputTooLarge,
+                "input exceeds extraction policy byte limit",
+                Vec::new(),
+            );
+        }
+
+        let extension = file_extension(artifact.relative_path.as_str());
+        let extracted = match extension.as_deref() {
+            Some("json") => match serde_json::from_slice::<Value>(bytes) {
+                Ok(value) => match serde_json::to_string_pretty(&value) {
+                    Ok(mut text) => {
+                        text.push('\n');
+                        Ok(text)
+                    }
+                    Err(error) => Err((
+                        ExtractionFailureKind::JsonParseError,
+                        format!("failed to render JSON text: {error}"),
+                    )),
+                },
+                Err(error) => Err((
+                    ExtractionFailureKind::JsonParseError,
+                    format!("failed to parse JSON input: {error}"),
+                )),
+            },
+            _ => match std::str::from_utf8(bytes) {
+                Ok(text) => Ok(normalize_newlines(text)),
+                Err(error) => Err((
+                    ExtractionFailureKind::DecodeError,
+                    format!("failed to decode UTF-8 text: {error}"),
+                )),
+            },
+        };
+
+        match extracted {
+            Ok(text) => success_result(
+                artifact,
+                self.extractor_name(),
+                self.extractor_version(),
+                self.command_or_crate_version(),
+                policy.output_format,
+                bytes.len(),
+                started,
+                text,
+                Vec::new(),
+                None,
+            ),
+            Err((failure_kind, detail)) => failure_result(
+                artifact,
+                self.extractor_name(),
+                self.extractor_version(),
+                self.command_or_crate_version(),
+                policy.output_format,
+                bytes.len(),
+                started,
+                failure_kind,
+                detail,
+                Vec::new(),
+            ),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ExternalExtractorSpec {
+    pub extractor_name: String,
+    pub extractor_version: String,
+    pub command_or_crate_version: String,
+    pub container_image: String,
+    pub command: Vec<String>,
+    pub supported_extensions: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ExternalCommandArtifactExtractor {
+    pub spec: ExternalExtractorSpec,
+}
+
+impl ArtifactExtractor for ExternalCommandArtifactExtractor {
+    fn extractor_name(&self) -> &'static str {
+        "psionic.sandboxed_external"
+    }
+
+    fn extractor_version(&self) -> &'static str {
+        "1.0.0"
+    }
+
+    fn command_or_crate_version(&self) -> &'static str {
+        "external_command_spec"
+    }
+
+    fn supports(&self, artifact: &SourceArtifact) -> bool {
+        let extension = file_extension(artifact.relative_path.as_str());
+        extension.is_some_and(|extension| {
+            self.spec
+                .supported_extensions
+                .iter()
+                .any(|supported| supported == &extension)
+        })
+    }
+
+    fn extract(
+        &self,
+        artifact: &SourceArtifact,
+        bytes: &[u8],
+        policy: &ArtifactExtractionPolicy,
+    ) -> ArtifactExtractionResult {
+        let started = Instant::now();
+        if !extractor_allowed(self.spec.extractor_name.as_str(), policy) {
+            return failure_result(
+                artifact,
+                self.spec.extractor_name.as_str(),
+                self.spec.extractor_version.as_str(),
+                self.spec.command_or_crate_version.as_str(),
+                policy.output_format,
+                bytes.len(),
+                started,
+                ExtractionFailureKind::PolicyDenied,
+                "extractor is not allowed by extraction policy",
+                Vec::new(),
+            );
+        }
+        if bytes.len() > usize::try_from(policy.max_input_bytes).unwrap_or(usize::MAX) {
+            return failure_result(
+                artifact,
+                self.spec.extractor_name.as_str(),
+                self.spec.extractor_version.as_str(),
+                self.spec.command_or_crate_version.as_str(),
+                policy.output_format,
+                bytes.len(),
+                started,
+                ExtractionFailureKind::InputTooLarge,
+                "input exceeds extraction policy byte limit",
+                Vec::new(),
+            );
+        }
+        let warning = ExtractionWarning {
+            warning_code: "external_adapter_not_executed".to_string(),
+            message: format!(
+                "external extractor `{}` requires a live sandbox command executor",
+                self.spec.extractor_name
+            ),
+            metadata: BTreeMap::new(),
+        };
+        if !policy.external_tools_allowed {
+            return failure_result(
+                artifact,
+                self.spec.extractor_name.as_str(),
+                self.spec.extractor_version.as_str(),
+                self.spec.command_or_crate_version.as_str(),
+                policy.output_format,
+                bytes.len(),
+                started,
+                ExtractionFailureKind::PolicyDenied,
+                "external extraction is disabled by policy",
+                vec![warning],
+            );
+        }
+        failure_result(
+            artifact,
+            self.spec.extractor_name.as_str(),
+            self.spec.extractor_version.as_str(),
+            self.spec.command_or_crate_version.as_str(),
+            policy.output_format,
+            bytes.len(),
+            started,
+            ExtractionFailureKind::ExternalToolUnavailable,
+            "sandboxed external extractor is declared but no command executor was attached",
+            vec![warning],
+        )
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ArtifactExtractorRegistry {
+    pub external_extractors: Vec<ExternalCommandArtifactExtractor>,
+}
+
+impl Default for ArtifactExtractorRegistry {
+    fn default() -> Self {
+        Self {
+            external_extractors: default_external_extractors(),
+        }
+    }
+}
+
+impl ArtifactExtractorRegistry {
+    pub fn extract(
+        &self,
+        artifact: &SourceArtifact,
+        bytes: &[u8],
+        policy: &ArtifactExtractionPolicy,
+    ) -> ArtifactExtractionResult {
+        let native = NativeTextArtifactExtractor;
+        if native.supports(artifact) {
+            return native.extract(artifact, bytes, policy);
+        }
+        for extractor in &self.external_extractors {
+            if extractor.supports(artifact) {
+                return extractor.extract(artifact, bytes, policy);
+            }
+        }
+        let started = Instant::now();
+        failure_result(
+            artifact,
+            "psionic.registry",
+            "1.0.0",
+            "registry",
+            policy.output_format,
+            bytes.len(),
+            started,
+            ExtractionFailureKind::UnsupportedArtifact,
+            "no registered extractor supports this artifact",
+            Vec::new(),
+        )
+    }
+}
+
+pub fn default_external_extractors() -> Vec<ExternalCommandArtifactExtractor> {
+    vec![
+        external_spec(
+            "psionic.external.docx",
+            "1.0.0",
+            "pandoc@3.x",
+            "ghcr.io/openagents/legal-extractors:pandoc-3",
+            &["pandoc", "--from=docx", "--to=plain", "/workspace/inputs"],
+            &["docx"],
+        ),
+        external_spec(
+            "psionic.external.pdf",
+            "1.0.0",
+            "pdftotext@24.x",
+            "ghcr.io/openagents/legal-extractors:poppler-24",
+            &["pdftotext", "-layout", "/workspace/inputs", "-"],
+            &["pdf"],
+        ),
+        external_spec(
+            "psionic.external.pptx",
+            "1.0.0",
+            "pandoc@3.x",
+            "ghcr.io/openagents/legal-extractors:pandoc-3",
+            &["pandoc", "--from=pptx", "--to=plain", "/workspace/inputs"],
+            &["pptx"],
+        ),
+        external_spec(
+            "psionic.external.xlsx",
+            "1.0.0",
+            "python-openpyxl@3.x",
+            "ghcr.io/openagents/legal-extractors:office-3",
+            &[
+                "python",
+                "-m",
+                "openagents_extractors.xlsx",
+                "/workspace/inputs",
+            ],
+            &["xlsx"],
+        ),
+        external_spec(
+            "psionic.external.eml",
+            "1.0.0",
+            "python-email-policy-default",
+            "ghcr.io/openagents/legal-extractors:email-3",
+            &[
+                "python",
+                "-m",
+                "openagents_extractors.eml",
+                "/workspace/inputs",
+            ],
+            &["eml"],
+        ),
+    ]
+}
+
+pub fn extraction_receipt_digest(receipt: &ExtractionReceipt) -> Result<String, serde_json::Error> {
+    stable_json_digest("psionic.legal_benchmark.extraction_receipt.v1", receipt)
+}
+
+fn external_spec(
+    extractor_name: &str,
+    extractor_version: &str,
+    command_or_crate_version: &str,
+    container_image: &str,
+    command: &[&str],
+    supported_extensions: &[&str],
+) -> ExternalCommandArtifactExtractor {
+    ExternalCommandArtifactExtractor {
+        spec: ExternalExtractorSpec {
+            extractor_name: extractor_name.to_string(),
+            extractor_version: extractor_version.to_string(),
+            command_or_crate_version: command_or_crate_version.to_string(),
+            container_image: container_image.to_string(),
+            command: command.iter().map(|part| (*part).to_string()).collect(),
+            supported_extensions: supported_extensions
+                .iter()
+                .map(|extension| (*extension).to_string())
+                .collect(),
+        },
+    }
+}
+
+fn success_result(
+    artifact: &SourceArtifact,
+    extractor_name: &str,
+    extractor_version: &str,
+    command_or_crate_version: &str,
+    output_format: ExtractionOutputFormat,
+    input_len: usize,
+    started: Instant,
+    text: String,
+    warnings: Vec<ExtractionWarning>,
+    sandbox_receipt_ref: Option<String>,
+) -> ArtifactExtractionResult {
+    let output_bytes = text.as_bytes();
+    let output_hash = sha256_hex(output_bytes);
+    let output_artifact_id = format!("{}.extracted", artifact.artifact_id);
+    let receipt_id = receipt_id(
+        artifact.artifact_id.as_str(),
+        artifact.sha256.as_str(),
+        extractor_name,
+        output_hash.as_str(),
+        None,
+    );
+    let output_artifact = SourceArtifact {
+        artifact_id: output_artifact_id.clone(),
+        artifact_kind: ArtifactKind::ExtractedText,
+        relative_path: format!("extracted/{output_artifact_id}.txt"),
+        original_filename: format!("{}.txt", artifact.original_filename),
+        media_type: "text/plain".to_string(),
+        byte_size: u64::try_from(output_bytes.len()).unwrap_or(u64::MAX),
+        sha256: output_hash.clone(),
+        data_classification: artifact.data_classification,
+        provenance: Some(receipt_id.clone()),
+    };
+    let coverage = ExtractionCoverage {
+        input_byte_count: u64::try_from(input_len).unwrap_or(u64::MAX),
+        output_byte_count: u64::try_from(output_bytes.len()).unwrap_or(u64::MAX),
+        output_char_count: u64::try_from(text.chars().count()).unwrap_or(u64::MAX),
+        ..ExtractionCoverage::default()
+    };
+    ArtifactExtractionResult {
+        receipt: ExtractionReceipt {
+            schema_version: LEGAL_BENCHMARK_EXTRACTION_SCHEMA_VERSION,
+            receipt_id,
+            source_artifact_id: artifact.artifact_id.clone(),
+            source_artifact_hash: artifact.sha256.clone(),
+            source_artifact_path: artifact.relative_path.clone(),
+            input_media_type: artifact.media_type.clone(),
+            input_byte_size: artifact.byte_size,
+            extractor_name: extractor_name.to_string(),
+            extractor_version: extractor_version.to_string(),
+            command_or_crate_version: command_or_crate_version.to_string(),
+            output_format,
+            output_artifact_id: Some(output_artifact_id),
+            output_hash: Some(output_hash),
+            output_byte_size: Some(u64::try_from(output_bytes.len()).unwrap_or(u64::MAX)),
+            coverage,
+            warnings,
+            failure_kind: None,
+            failure_detail: None,
+            sandbox_receipt_ref,
+            elapsed_ms: elapsed_ms(started),
+            metadata: BTreeMap::new(),
+        },
+        extracted_artifact: Some(ExtractedArtifact {
+            artifact: output_artifact,
+            text,
+        }),
+    }
+}
+
+fn failure_result(
+    artifact: &SourceArtifact,
+    extractor_name: &str,
+    extractor_version: &str,
+    command_or_crate_version: &str,
+    output_format: ExtractionOutputFormat,
+    input_len: usize,
+    started: Instant,
+    failure_kind: ExtractionFailureKind,
+    failure_detail: impl Into<String>,
+    warnings: Vec<ExtractionWarning>,
+) -> ArtifactExtractionResult {
+    let failure_detail = failure_detail.into();
+    let receipt_id = receipt_id(
+        artifact.artifact_id.as_str(),
+        artifact.sha256.as_str(),
+        extractor_name,
+        failure_detail.as_str(),
+        Some(failure_kind),
+    );
+    ArtifactExtractionResult {
+        receipt: ExtractionReceipt {
+            schema_version: LEGAL_BENCHMARK_EXTRACTION_SCHEMA_VERSION,
+            receipt_id,
+            source_artifact_id: artifact.artifact_id.clone(),
+            source_artifact_hash: artifact.sha256.clone(),
+            source_artifact_path: artifact.relative_path.clone(),
+            input_media_type: artifact.media_type.clone(),
+            input_byte_size: artifact.byte_size,
+            extractor_name: extractor_name.to_string(),
+            extractor_version: extractor_version.to_string(),
+            command_or_crate_version: command_or_crate_version.to_string(),
+            output_format,
+            output_artifact_id: None,
+            output_hash: None,
+            output_byte_size: None,
+            coverage: ExtractionCoverage {
+                input_byte_count: u64::try_from(input_len).unwrap_or(u64::MAX),
+                ..ExtractionCoverage::default()
+            },
+            warnings,
+            failure_kind: Some(failure_kind),
+            failure_detail: Some(failure_detail),
+            sandbox_receipt_ref: None,
+            elapsed_ms: elapsed_ms(started),
+            metadata: BTreeMap::new(),
+        },
+        extracted_artifact: None,
+    }
+}
+
+fn extractor_allowed(extractor_name: &str, policy: &ArtifactExtractionPolicy) -> bool {
+    policy.extractor_allowlist.is_empty()
+        || policy
+            .extractor_allowlist
+            .iter()
+            .any(|allowed| allowed == extractor_name)
+}
+
+fn is_native_text_artifact(artifact: &SourceArtifact) -> bool {
+    let extension = file_extension(artifact.relative_path.as_str());
+    extension.as_deref().is_some_and(|extension| {
+        matches!(
+            extension,
+            "txt"
+                | "text"
+                | "md"
+                | "markdown"
+                | "json"
+                | "csv"
+                | "tsv"
+                | "xml"
+                | "html"
+                | "htm"
+                | "yaml"
+                | "yml"
+                | "toml"
+                | "log"
+        )
+    }) || artifact.media_type.starts_with("text/")
+        || artifact.media_type == "application/json"
+}
+
+fn normalize_newlines(value: &str) -> String {
+    value.replace("\r\n", "\n").replace('\r', "\n")
+}
+
+fn receipt_id(
+    artifact_id: &str,
+    artifact_hash: &str,
+    extractor_name: &str,
+    output_or_failure_hash: &str,
+    failure_kind: Option<ExtractionFailureKind>,
+) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(artifact_id.as_bytes());
+    hasher.update(b"|");
+    hasher.update(artifact_hash.as_bytes());
+    hasher.update(b"|");
+    hasher.update(extractor_name.as_bytes());
+    hasher.update(b"|");
+    hasher.update(output_or_failure_hash.as_bytes());
+    if let Some(kind) = failure_kind {
+        hasher.update(b"|");
+        hasher.update(format!("{kind:?}").as_bytes());
+    }
+    let digest = hex::encode(hasher.finalize());
+    format!("extraction.receipt.{artifact_id}.{digest}")
+}
+
+fn sha256_hex(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    hex::encode(hasher.finalize())
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    u64::try_from(started.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+fn file_extension(path: &str) -> Option<String> {
+    Path::new(path)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_lowercase())
+        .filter(|extension| !extension.is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        DataClassification, LEGAL_BENCHMARK_SCHEMA_VERSION, RunRecord, ScoreReport,
+        artifact_from_file,
+    };
+    use std::path::PathBuf;
+
+    fn samples_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../fixtures/legal_benchmark/extraction_samples")
+    }
+
+    fn sample_artifact(name: &str) -> SourceArtifact {
+        let root = samples_root();
+        artifact_from_file(
+            format!("sample.{name}"),
+            ArtifactKind::SourceDocument,
+            root.as_path(),
+            root.join(name),
+            DataClassification::PublicReference,
+            Some("fixture".to_string()),
+        )
+        .expect("sample artifact")
+    }
+
+    #[test]
+    fn native_text_extractor_extracts_plain_text() {
+        let artifact = sample_artifact("sample.txt");
+        let bytes = std::fs::read(samples_root().join("sample.txt")).expect("read sample");
+        let result = NativeTextArtifactExtractor.extract(
+            &artifact,
+            bytes.as_slice(),
+            &ArtifactExtractionPolicy::default(),
+        );
+
+        assert!(result.receipt.failure_kind.is_none());
+        assert_eq!(result.receipt.source_artifact_hash, artifact.sha256);
+        assert!(result.receipt.output_hash.is_some());
+        assert_eq!(result.receipt.warnings.len(), 0);
+        let extracted = result.extracted_artifact.expect("extracted text");
+        assert!(extracted.text.contains("Settlement agreement"));
+        assert_eq!(
+            extracted.artifact.artifact_kind,
+            ArtifactKind::ExtractedText
+        );
+    }
+
+    #[test]
+    fn native_json_extractor_parses_and_pretty_prints_json() {
+        let artifact = sample_artifact("sample.json");
+        let bytes = std::fs::read(samples_root().join("sample.json")).expect("read sample");
+        let result = ArtifactExtractorRegistry::default().extract(
+            &artifact,
+            bytes.as_slice(),
+            &ArtifactExtractionPolicy {
+                output_format: ExtractionOutputFormat::JsonText,
+                ..ArtifactExtractionPolicy::default()
+            },
+        );
+
+        assert!(result.receipt.failure_kind.is_none());
+        let extracted = result.extracted_artifact.expect("json text");
+        assert!(extracted.text.contains("\"matter\""));
+        assert_eq!(result.receipt.coverage.input_byte_count, artifact.byte_size);
+    }
+
+    #[test]
+    fn major_harvey_extensions_are_supported_or_structurally_failed() {
+        let registry = ArtifactExtractorRegistry::default();
+        let policy = ArtifactExtractionPolicy::default();
+        let expected = [
+            ("sample.txt", None),
+            ("sample.md", None),
+            ("sample.json", None),
+            (
+                "sample.docx",
+                Some(ExtractionFailureKind::ExternalToolUnavailable),
+            ),
+            (
+                "sample.pdf",
+                Some(ExtractionFailureKind::ExternalToolUnavailable),
+            ),
+            (
+                "sample.pptx",
+                Some(ExtractionFailureKind::ExternalToolUnavailable),
+            ),
+            (
+                "sample.xlsx",
+                Some(ExtractionFailureKind::ExternalToolUnavailable),
+            ),
+            (
+                "sample.eml",
+                Some(ExtractionFailureKind::ExternalToolUnavailable),
+            ),
+        ];
+
+        for (name, expected_failure) in expected {
+            let artifact = sample_artifact(name);
+            let bytes = std::fs::read(samples_root().join(name)).expect("read sample");
+            let result = registry.extract(&artifact, bytes.as_slice(), &policy);
+            assert_eq!(result.receipt.failure_kind, expected_failure);
+            assert_eq!(result.receipt.source_artifact_hash, artifact.sha256);
+            assert_eq!(result.receipt.input_byte_size, artifact.byte_size);
+        }
+    }
+
+    #[test]
+    fn external_policy_denial_is_structured() {
+        let registry = ArtifactExtractorRegistry::default();
+        let artifact = sample_artifact("sample.docx");
+        let bytes = std::fs::read(samples_root().join("sample.docx")).expect("read sample");
+        let result = registry.extract(
+            &artifact,
+            bytes.as_slice(),
+            &ArtifactExtractionPolicy {
+                external_tools_allowed: false,
+                ..ArtifactExtractionPolicy::default()
+            },
+        );
+
+        assert_eq!(
+            result.receipt.failure_kind,
+            Some(ExtractionFailureKind::PolicyDenied)
+        );
+        assert_eq!(result.receipt.warnings.len(), 1);
+    }
+
+    #[test]
+    fn extraction_receipt_fixture_parses_for_operator_import() {
+        let receipts: Vec<ExtractionReceipt> = serde_json::from_str(include_str!(
+            "../../../fixtures/legal_benchmark/extraction_receipts_sample.json"
+        ))
+        .expect("receipt fixture parses");
+        assert_eq!(receipts.len(), 2);
+        assert!(receipts[0].failure_kind.is_none());
+        assert_eq!(
+            receipts[1].failure_kind,
+            Some(ExtractionFailureKind::ExternalToolUnavailable)
+        );
+    }
+
+    #[test]
+    fn run_and_score_reports_retain_extraction_receipt_refs() {
+        let receipt_ref = "extraction.receipt.sample.txt.abc123".to_string();
+        let mut run_record: RunRecord = serde_json::from_value(serde_json::json!({
+            "schema_version": LEGAL_BENCHMARK_SCHEMA_VERSION,
+            "run_id": "run.legal.sample",
+            "task_id": "task.legal.sample",
+            "task_version": "v1",
+            "input_artifact_manifest_hash": "input",
+            "run_config_hash": "config",
+            "output_artifact_manifest_hash": "output",
+            "terminal_state": "submitted",
+            "transcript": [],
+            "tool_calls": [],
+            "metrics": {
+                "model_turns": 1,
+                "tool_call_count": 0,
+                "input_tokens": 10,
+                "output_tokens": 20,
+                "wall_time_ms": 30,
+                "estimated_cost_micro_usd": 40
+            }
+        }))
+        .expect("run record parses");
+        run_record.extraction_receipt_refs.push(receipt_ref.clone());
+
+        let mut score_report: ScoreReport = serde_json::from_value(serde_json::json!({
+            "schema_version": LEGAL_BENCHMARK_SCHEMA_VERSION,
+            "score_report_id": "score.legal.sample",
+            "run_id": "run.legal.sample",
+            "task_id": "task.legal.sample",
+            "task_version": "v1",
+            "run_record_hash": "run",
+            "output_artifact_manifest_hash": "output",
+            "all_pass": false,
+            "criterion_pass_rate_bps": 0,
+            "criterion_results": [],
+            "metrics": {
+                "model_turns": 1,
+                "tool_call_count": 0,
+                "input_tokens": 10,
+                "output_tokens": 20,
+                "wall_time_ms": 30,
+                "estimated_cost_micro_usd": 40
+            }
+        }))
+        .expect("score report parses");
+        score_report
+            .extraction_receipt_refs
+            .push(receipt_ref.clone());
+
+        assert_eq!(
+            run_record.extraction_receipt_refs,
+            vec![receipt_ref.clone()]
+        );
+        assert_eq!(score_report.extraction_receipt_refs, vec![receipt_ref]);
+    }
+}

--- a/crates/psionic-eval/src/lib.rs
+++ b/crates/psionic-eval/src/lib.rs
@@ -11,9 +11,11 @@
 )]
 
 mod legal_benchmark;
+mod legal_benchmark_extraction;
 mod legal_benchmark_harvey;
 
 pub use legal_benchmark::*;
+pub use legal_benchmark_extraction::*;
 pub use legal_benchmark_harvey::*;
 
 #[cfg(feature = "full")]

--- a/docs/LEGAL_BENCHMARK_ENGINE.md
+++ b/docs/LEGAL_BENCHMARK_ENGINE.md
@@ -118,9 +118,34 @@ scratch and output paths at `/workspace/scratch` and `/workspace/output`.
 Path validation canonicalizes host roots and rejects traversal or symlink
 escapes before a container command is built.
 
+## Document Extraction
+
+The extraction contract lives in
+`crates/psionic-eval/src/legal_benchmark_extraction.rs`.
+
+It defines:
+
+- `ArtifactExtractor`
+- `ArtifactExtractionPolicy`
+- `ArtifactExtractionResult`
+- `ExtractionReceipt`
+- `ExtractionCoverage`
+- `ExtractionFailureKind`
+- `ArtifactExtractorRegistry`
+
+Day-one native extraction handles text, Markdown, JSON, CSV/TSV, XML/HTML,
+YAML, TOML, and log-like UTF-8 inputs without external tools. The registry also
+declares pinned sandboxed external adapter specs for DOCX, PDF, PPTX, XLSX,
+and EML. Until a live sandbox command executor is attached, those external
+adapters return structured `external_tool_unavailable` or policy-denied
+receipts instead of panicking or crashing a sweep.
+
+Run records and score reports now retain `extraction_receipt_refs` so operator
+surfaces can distinguish extraction failure, missing content, and bad
+reasoning.
+
 ## Next Work
 
-The next implementation issue is document extraction receipts. It should run
-extractors through the sandbox boundary, attach versioned extractor identity,
-input hashes, output hashes, warnings, and coverage metadata to derived
-artifacts before runner and evaluator work depends on extracted text.
+The next implementation issue is the benchmark tool bundle. It should consume
+the extraction receipts here and keep every search, quote, citation, draft,
+and validation call receipt-backed.

--- a/fixtures/legal_benchmark/extraction_receipts_sample.json
+++ b/fixtures/legal_benchmark/extraction_receipts_sample.json
@@ -1,0 +1,52 @@
+[
+  {
+    "schema_version": 1,
+    "receipt_id": "extraction.receipt.sample.txt.example",
+    "source_artifact_id": "sample.txt",
+    "source_artifact_hash": "289200cb8c52565a763298b02ece66cb58727596de6ba2c2bbfb09098dcb1789",
+    "source_artifact_path": "sample.txt",
+    "input_media_type": "text/plain",
+    "input_byte_size": 82,
+    "extractor_name": "psionic.native_text",
+    "extractor_version": "1.0.0",
+    "command_or_crate_version": "std::str+serde_json",
+    "output_format": "plain_text",
+    "output_artifact_id": "sample.txt.extracted",
+    "output_hash": "289200cb8c52565a763298b02ece66cb58727596de6ba2c2bbfb09098dcb1789",
+    "output_byte_size": 82,
+    "coverage": {
+      "input_byte_count": 82,
+      "output_byte_count": 82,
+      "output_char_count": 82
+    },
+    "warnings": [],
+    "elapsed_ms": 1
+  },
+  {
+    "schema_version": 1,
+    "receipt_id": "extraction.receipt.sample.docx.example",
+    "source_artifact_id": "sample.docx",
+    "source_artifact_hash": "ad58ba90a0911058264b6607dac980c8e0f458de7840402042cc0b3e477b325c",
+    "source_artifact_path": "sample.docx",
+    "input_media_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "input_byte_size": 55,
+    "extractor_name": "psionic.external.docx",
+    "extractor_version": "1.0.0",
+    "command_or_crate_version": "pandoc@3.x",
+    "output_format": "plain_text",
+    "coverage": {
+      "input_byte_count": 55,
+      "output_byte_count": 0,
+      "output_char_count": 0
+    },
+    "warnings": [
+      {
+        "warning_code": "external_adapter_not_executed",
+        "message": "external extractor requires a live sandbox command executor"
+      }
+    ],
+    "failure_kind": "external_tool_unavailable",
+    "failure_detail": "sandboxed external extractor is declared but no command executor was attached",
+    "elapsed_ms": 1
+  }
+]

--- a/fixtures/legal_benchmark/extraction_samples/sample.docx
+++ b/fixtures/legal_benchmark/extraction_samples/sample.docx
@@ -1,0 +1,1 @@
+placeholder docx bytes for structured failure coverage

--- a/fixtures/legal_benchmark/extraction_samples/sample.eml
+++ b/fixtures/legal_benchmark/extraction_samples/sample.eml
@@ -1,0 +1,5 @@
+From: counsel@example.com
+To: client@example.com
+Subject: Closing checklist
+
+Please confirm the signature packet before noon.

--- a/fixtures/legal_benchmark/extraction_samples/sample.json
+++ b/fixtures/legal_benchmark/extraction_samples/sample.json
@@ -1,0 +1,5 @@
+{
+  "matter": "employment",
+  "documents": 2,
+  "privileged": false
+}

--- a/fixtures/legal_benchmark/extraction_samples/sample.md
+++ b/fixtures/legal_benchmark/extraction_samples/sample.md
@@ -1,0 +1,4 @@
+# Lease Review
+
+- Notice period: 30 days
+- Governing law: Delaware

--- a/fixtures/legal_benchmark/extraction_samples/sample.pdf
+++ b/fixtures/legal_benchmark/extraction_samples/sample.pdf
@@ -1,0 +1,2 @@
+%PDF-1.4
+placeholder pdf bytes for structured failure coverage

--- a/fixtures/legal_benchmark/extraction_samples/sample.pptx
+++ b/fixtures/legal_benchmark/extraction_samples/sample.pptx
@@ -1,0 +1,1 @@
+placeholder pptx bytes for structured failure coverage

--- a/fixtures/legal_benchmark/extraction_samples/sample.txt
+++ b/fixtures/legal_benchmark/extraction_samples/sample.txt
@@ -1,0 +1,2 @@
+Settlement agreement summary:
+The buyer must deliver closing documents by Friday.

--- a/fixtures/legal_benchmark/extraction_samples/sample.xlsx
+++ b/fixtures/legal_benchmark/extraction_samples/sample.xlsx
@@ -1,0 +1,1 @@
+placeholder xlsx bytes for structured failure coverage


### PR DESCRIPTION
## Summary

- Adds the Rust-owned legal benchmark document extraction contracts and receipt schema.
- Implements native extraction for text, Markdown, JSON, and other UTF-8 text-like formats.
- Adds declared sandboxed external extractor specs for DOCX, PDF, PPTX, XLSX, and EML that return structured failures until a command executor is attached.
- Adds extraction receipt refs to run records and score reports.
- Adds sample fixtures, receipt examples, and a Harvey 20-task slice extraction example.

## Validation

- `cargo test -p psionic-eval --no-default-features --lib legal_benchmark_extraction`
- `cargo test -p psionic-eval --no-default-features --lib`
- `cargo test -p psionic-eval --lib legal_benchmark_extraction`
- `cargo run -q -p psionic-eval --no-default-features --example legal_benchmark_extract_slice -- /Users/christopherdavid/work/competition/repos/harvey-labs/tasks 5aa41694 20`
- `python3 -m json.tool fixtures/legal_benchmark/extraction_receipts_sample.json`
- `git diff --cached --check`

Closes #989
