### PR TITLE
Add legal benchmark evaluator

### DIFF
--- a/crates/psionic-eval/src/legal_benchmark.rs
+++ b/crates/psionic-eval/src/legal_benchmark.rs
@@ -525,6 +525,15 @@ pub struct CriterionResult {
     pub judge_prompt_hash: String,
     /// Raw judge response hash.
     pub raw_response_hash: String,
+    /// Optional judge confidence in basis points.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub confidence_bps: Option<u16>,
+    /// Judge latency for this criterion.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub judge_latency_ms: Option<u64>,
+    /// Estimated criterion judging cost in microdollars.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub judge_cost_micro_usd: Option<u64>,
 }
 
 /// Criterion verdict family.
@@ -566,6 +575,12 @@ pub struct ScoreReport {
     pub criterion_results: Vec<CriterionResult>,
     /// Run metrics copied into the report.
     pub metrics: RunMetrics,
+    /// Output/source document coverage in basis points.
+    #[serde(default)]
+    pub document_coverage_bps: u32,
+    /// Human-readable failure diagnostics retained for reporting.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failure_diagnostics: Vec<String>,
     /// Extraction receipt ids or hashes considered by the scorer.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extraction_receipt_refs: Vec<String>,

--- a/crates/psionic-eval/src/legal_benchmark_evaluator.rs
+++ b/crates/psionic-eval/src/legal_benchmark_evaluator.rs
@@ -1,0 +1,657 @@
+//! Criterion-scoped evaluator and judge adapter for legal benchmark runs.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use thiserror::Error;
+
+use crate::{
+    ArtifactKind, ArtifactManifest, ArtifactManifestError, BenchmarkTaskSpec, CriterionResult,
+    CriterionSpec, CriterionVerdict, DataClassification, DeliverableKind, DeliverableSpec,
+    JudgePolicy, Metadata, RunRecord, ScoreReport, SourceArtifact, artifact_from_file,
+    artifact_manifest_digest, run_record_digest, score_report_digest, stable_json_digest,
+};
+
+pub const LEGAL_BENCHMARK_EVALUATOR_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkEvaluationInput {
+    pub task_spec: BenchmarkTaskSpec,
+    pub run_record: RunRecord,
+    pub output_artifact_manifest: ArtifactManifest,
+    pub output_root: PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkPrecheck {
+    pub precheck_id: String,
+    pub passed: bool,
+    pub detail: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub evidence_refs: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkJudgeRequest {
+    pub schema_version: u16,
+    pub criterion: CriterionSpec,
+    pub prompt_template_id: String,
+    pub prompt_template_hash: String,
+    pub judge_model: String,
+    pub output_text: String,
+    pub evidence_refs: Vec<String>,
+    #[serde(default, skip_serializing_if = "Metadata::is_empty")]
+    pub metadata: Metadata,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkJudgeResponse {
+    pub verdict: CriterionVerdict,
+    pub reasoning: String,
+    pub confidence_bps: Option<u16>,
+    pub raw_response: Value,
+    pub latency_ms: u64,
+    pub cost_micro_usd: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkEvaluationResult {
+    pub score_report: ScoreReport,
+    pub prechecks: Vec<LegalBenchmarkPrecheck>,
+    pub score_report_hash: String,
+}
+
+#[derive(Debug, Error)]
+pub enum LegalBenchmarkEvaluationError {
+    #[error("I/O error at {path}: {source}")]
+    Io {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+    #[error("JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+    #[error("artifact manifest error: {0}")]
+    ArtifactManifest(#[from] ArtifactManifestError),
+    #[error("judge error: {0}")]
+    Judge(String),
+}
+
+pub trait LegalBenchmarkJudgeAdapter {
+    fn judge(
+        &mut self,
+        request: &LegalBenchmarkJudgeRequest,
+    ) -> Result<LegalBenchmarkJudgeResponse, LegalBenchmarkEvaluationError>;
+}
+
+#[derive(Clone, Debug)]
+pub struct MockLegalBenchmarkJudge {
+    verdict: CriterionVerdict,
+    reasoning: String,
+    confidence_bps: Option<u16>,
+}
+
+impl MockLegalBenchmarkJudge {
+    pub fn pass() -> Self {
+        Self {
+            verdict: CriterionVerdict::Pass,
+            reasoning: String::from("mock judge passed the criterion"),
+            confidence_bps: Some(10_000),
+        }
+    }
+
+    pub fn fail(reasoning: impl Into<String>) -> Self {
+        Self {
+            verdict: CriterionVerdict::Fail,
+            reasoning: reasoning.into(),
+            confidence_bps: Some(10_000),
+        }
+    }
+}
+
+impl LegalBenchmarkJudgeAdapter for MockLegalBenchmarkJudge {
+    fn judge(
+        &mut self,
+        request: &LegalBenchmarkJudgeRequest,
+    ) -> Result<LegalBenchmarkJudgeResponse, LegalBenchmarkEvaluationError> {
+        Ok(LegalBenchmarkJudgeResponse {
+            verdict: self.verdict,
+            reasoning: self.reasoning.clone(),
+            confidence_bps: self.confidence_bps,
+            raw_response: json!({
+                "mock": true,
+                "criterion_id": request.criterion.criterion_id,
+                "verdict": self.verdict,
+                "reasoning": self.reasoning,
+            }),
+            latency_ms: 1,
+            cost_micro_usd: 0,
+        })
+    }
+}
+
+pub fn evaluate_legal_benchmark_run<J>(
+    input: &LegalBenchmarkEvaluationInput,
+    judge: &mut J,
+) -> Result<LegalBenchmarkEvaluationResult, LegalBenchmarkEvaluationError>
+where
+    J: LegalBenchmarkJudgeAdapter,
+{
+    let prechecks = run_prechecks(input)?;
+    let failure_diagnostics = prechecks
+        .iter()
+        .filter(|precheck| !precheck.passed)
+        .map(|precheck| format!("{}: {}", precheck.precheck_id, precheck.detail))
+        .collect::<Vec<_>>();
+    let mut criterion_results = Vec::new();
+    let prompt_template = default_judge_prompt_template(&input.task_spec.judge_policy);
+    let prompt_template_hash = stable_json_digest(
+        "psionic.legal_benchmark.judge_prompt_template.v1",
+        &prompt_template,
+    )?;
+    let mut total_judge_cost = 0_u64;
+    let mut total_judge_latency = 0_u64;
+
+    for criterion in &input.task_spec.criteria {
+        if let Some(result) =
+            deterministic_criterion_result(criterion, input, &failure_diagnostics)?
+        {
+            criterion_results.push(result);
+            continue;
+        }
+        let output_text = criterion_output_text(criterion, input)?;
+        let judge_request = LegalBenchmarkJudgeRequest {
+            schema_version: LEGAL_BENCHMARK_EVALUATOR_SCHEMA_VERSION,
+            criterion: criterion.clone(),
+            prompt_template_id: input.task_spec.judge_policy.prompt_template_id.clone(),
+            prompt_template_hash: prompt_template_hash.clone(),
+            judge_model: input.task_spec.judge_policy.model.clone(),
+            output_text,
+            evidence_refs: criterion_evidence_refs(criterion, input),
+            metadata: Metadata::new(),
+        };
+        let judge_response = judge.judge(&judge_request)?;
+        total_judge_cost = total_judge_cost.saturating_add(judge_response.cost_micro_usd);
+        total_judge_latency = total_judge_latency.saturating_add(judge_response.latency_ms);
+        criterion_results.push(criterion_result_from_judge(
+            criterion,
+            &judge_request,
+            judge_response,
+        )?);
+    }
+
+    let passed_count = criterion_results
+        .iter()
+        .filter(|result| result.passed)
+        .count();
+    let criterion_pass_rate_bps = if criterion_results.is_empty() {
+        0
+    } else {
+        u32::try_from((passed_count * 10_000) / criterion_results.len()).unwrap_or(0)
+    };
+    let all_pass = criterion_results
+        .iter()
+        .all(|result| result.verdict == CriterionVerdict::Pass);
+    let mut metrics = input.run_record.metrics.clone();
+    metrics.estimated_cost_micro_usd = metrics
+        .estimated_cost_micro_usd
+        .saturating_add(total_judge_cost);
+    metrics.wall_time_ms = metrics.wall_time_ms.saturating_add(total_judge_latency);
+    let output_manifest_hash = artifact_manifest_digest(&input.output_artifact_manifest)?;
+    let run_record_hash = run_record_digest(&input.run_record)?;
+    let mut metadata = Metadata::new();
+    metadata.insert(
+        String::from("precheck_count"),
+        json!(u64::try_from(prechecks.len()).unwrap_or(u64::MAX)),
+    );
+    metadata.insert(
+        String::from("judge_prompt_template_hash"),
+        Value::String(prompt_template_hash),
+    );
+    let score_report = ScoreReport {
+        schema_version: crate::LEGAL_BENCHMARK_SCHEMA_VERSION,
+        score_report_id: format!(
+            "score.{}.{}",
+            input.run_record.run_id, input.task_spec.judge_policy.prompt_template_id
+        ),
+        run_id: input.run_record.run_id.clone(),
+        task_id: input.task_spec.task_id.clone(),
+        task_version: input.task_spec.task_version.clone(),
+        run_record_hash,
+        output_artifact_manifest_hash: output_manifest_hash,
+        all_pass,
+        criterion_pass_rate_bps,
+        criterion_results,
+        metrics,
+        document_coverage_bps: document_coverage_bps(input),
+        failure_diagnostics,
+        extraction_receipt_refs: input.run_record.extraction_receipt_refs.clone(),
+        metadata,
+    };
+    let score_report_hash = score_report_digest(&score_report)?;
+    Ok(LegalBenchmarkEvaluationResult {
+        score_report,
+        prechecks,
+        score_report_hash,
+    })
+}
+
+fn run_prechecks(
+    input: &LegalBenchmarkEvaluationInput,
+) -> Result<Vec<LegalBenchmarkPrecheck>, LegalBenchmarkEvaluationError> {
+    let mut prechecks = Vec::new();
+    let expected_manifest_hash = artifact_manifest_digest(&input.output_artifact_manifest)?;
+    prechecks.push(LegalBenchmarkPrecheck {
+        precheck_id: String::from("output_manifest_hash"),
+        passed: expected_manifest_hash == input.run_record.output_artifact_manifest_hash,
+        detail: String::from("output manifest hash matches run record"),
+        evidence_refs: vec![input.output_artifact_manifest.manifest_id.clone()],
+    });
+    for deliverable in &input.task_spec.deliverables {
+        prechecks.push(check_deliverable(input, deliverable)?);
+    }
+    for artifact in &input.output_artifact_manifest.artifacts {
+        prechecks.push(check_manifest_artifact(input, artifact)?);
+    }
+    Ok(prechecks)
+}
+
+fn check_deliverable(
+    input: &LegalBenchmarkEvaluationInput,
+    deliverable: &DeliverableSpec,
+) -> Result<LegalBenchmarkPrecheck, LegalBenchmarkEvaluationError> {
+    let path = input.output_root.join(&deliverable.required_path);
+    let exists = path.is_file();
+    let readable = exists && fs::read(&path).is_ok();
+    let type_matches = exists && deliverable_type_matches(deliverable, &path);
+    let passed = if deliverable.required {
+        exists && readable && type_matches
+    } else {
+        !exists || (readable && type_matches)
+    };
+    Ok(LegalBenchmarkPrecheck {
+        precheck_id: format!("deliverable.{}", deliverable.deliverable_id),
+        passed,
+        detail: format!(
+            "exists={exists}; readable={readable}; type_matches={type_matches}; path={}",
+            deliverable.required_path
+        ),
+        evidence_refs: vec![deliverable.required_path.clone()],
+    })
+}
+
+fn check_manifest_artifact(
+    input: &LegalBenchmarkEvaluationInput,
+    artifact: &SourceArtifact,
+) -> Result<LegalBenchmarkPrecheck, LegalBenchmarkEvaluationError> {
+    let path = input.output_root.join(&artifact.relative_path);
+    if !path.is_file() {
+        return Ok(LegalBenchmarkPrecheck {
+            precheck_id: format!("artifact.{}", artifact.artifact_id),
+            passed: false,
+            detail: format!("manifest artifact missing at {}", artifact.relative_path),
+            evidence_refs: vec![artifact.artifact_id.clone()],
+        });
+    }
+    let rebuilt = artifact_from_file(
+        artifact.artifact_id.clone(),
+        artifact.artifact_kind,
+        &input.output_root,
+        &path,
+        artifact.data_classification,
+        artifact.provenance.clone(),
+    )?;
+    let passed = rebuilt.sha256 == artifact.sha256
+        && rebuilt.byte_size == artifact.byte_size
+        && rebuilt.media_type == artifact.media_type;
+    Ok(LegalBenchmarkPrecheck {
+        precheck_id: format!("artifact.{}", artifact.artifact_id),
+        passed,
+        detail: format!("manifest artifact verifies at {}", artifact.relative_path),
+        evidence_refs: vec![artifact.artifact_id.clone()],
+    })
+}
+
+fn deterministic_criterion_result(
+    criterion: &CriterionSpec,
+    input: &LegalBenchmarkEvaluationInput,
+    failure_diagnostics: &[String],
+) -> Result<Option<CriterionResult>, LegalBenchmarkEvaluationError> {
+    if criterion.deliverable_ids.is_empty() || failure_diagnostics.is_empty() {
+        return Ok(None);
+    }
+    let deliverable_ids = criterion
+        .deliverable_ids
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    let failed_deliverable = input
+        .task_spec
+        .deliverables
+        .iter()
+        .filter(|deliverable| deliverable_ids.contains(&deliverable.deliverable_id))
+        .any(|deliverable| {
+            failure_diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.contains(&deliverable.deliverable_id))
+        });
+    if !failed_deliverable {
+        return Ok(None);
+    }
+    Ok(Some(CriterionResult {
+        criterion_id: criterion.criterion_id.clone(),
+        passed: false,
+        verdict: CriterionVerdict::Fail,
+        reasoning: String::from("required deliverable failed deterministic precheck"),
+        evidence_refs: criterion.deliverable_ids.clone(),
+        judge_model: String::from("deterministic_precheck"),
+        judge_prompt_hash: String::from("deterministic_precheck"),
+        raw_response_hash: stable_json_digest(
+            "psionic.legal_benchmark.deterministic_criterion.v1",
+            criterion,
+        )?,
+        confidence_bps: Some(10_000),
+        judge_latency_ms: Some(0),
+        judge_cost_micro_usd: Some(0),
+    }))
+}
+
+fn criterion_result_from_judge(
+    criterion: &CriterionSpec,
+    request: &LegalBenchmarkJudgeRequest,
+    response: LegalBenchmarkJudgeResponse,
+) -> Result<CriterionResult, LegalBenchmarkEvaluationError> {
+    let raw_response_hash = stable_json_digest(
+        "psionic.legal_benchmark.judge_raw_response.v1",
+        &response.raw_response,
+    )?;
+    Ok(CriterionResult {
+        criterion_id: criterion.criterion_id.clone(),
+        passed: response.verdict == CriterionVerdict::Pass,
+        verdict: response.verdict,
+        reasoning: response.reasoning,
+        evidence_refs: request.evidence_refs.clone(),
+        judge_model: request.judge_model.clone(),
+        judge_prompt_hash: request.prompt_template_hash.clone(),
+        raw_response_hash,
+        confidence_bps: response.confidence_bps,
+        judge_latency_ms: Some(response.latency_ms),
+        judge_cost_micro_usd: Some(response.cost_micro_usd),
+    })
+}
+
+fn criterion_output_text(
+    criterion: &CriterionSpec,
+    input: &LegalBenchmarkEvaluationInput,
+) -> Result<String, LegalBenchmarkEvaluationError> {
+    let mut text = String::new();
+    let deliverable_ids = criterion
+        .deliverable_ids
+        .iter()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    for deliverable in &input.task_spec.deliverables {
+        if !deliverable_ids.is_empty() && !deliverable_ids.contains(&deliverable.deliverable_id) {
+            continue;
+        }
+        let path = input.output_root.join(&deliverable.required_path);
+        if path.is_file() {
+            let content =
+                fs::read_to_string(&path).map_err(|source| LegalBenchmarkEvaluationError::Io {
+                    path: path.clone(),
+                    source,
+                })?;
+            text.push_str(&format!(
+                "\n\n# Deliverable {}\n{}\n",
+                deliverable.deliverable_id, content
+            ));
+        }
+    }
+    Ok(text)
+}
+
+fn criterion_evidence_refs(
+    criterion: &CriterionSpec,
+    input: &LegalBenchmarkEvaluationInput,
+) -> Vec<String> {
+    let mut refs = criterion.source_artifact_ids.clone();
+    refs.extend(criterion.deliverable_ids.iter().cloned());
+    if refs.is_empty() {
+        refs.extend(
+            input
+                .output_artifact_manifest
+                .artifacts
+                .iter()
+                .map(|artifact| artifact.artifact_id.clone()),
+        );
+    }
+    refs
+}
+
+fn deliverable_type_matches(deliverable: &DeliverableSpec, path: &Path) -> bool {
+    let extension = path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    match deliverable.deliverable_kind {
+        DeliverableKind::Text => matches!(extension.as_str(), "txt" | "text"),
+        DeliverableKind::Markdown => matches!(extension.as_str(), "md" | "markdown"),
+        DeliverableKind::Docx => extension == "docx",
+        DeliverableKind::Xlsx => extension == "xlsx",
+        DeliverableKind::Pdf => extension == "pdf",
+        DeliverableKind::Json => extension == "json",
+        DeliverableKind::Directory => path.is_dir(),
+        DeliverableKind::Other => true,
+    }
+}
+
+fn document_coverage_bps(input: &LegalBenchmarkEvaluationInput) -> u32 {
+    if input.task_spec.source_artifacts.is_empty() {
+        return 10_000;
+    }
+    let referenced = input
+        .task_spec
+        .criteria
+        .iter()
+        .flat_map(|criterion| criterion.source_artifact_ids.iter())
+        .collect::<BTreeSet<_>>();
+    u32::try_from((referenced.len() * 10_000) / input.task_spec.source_artifacts.len())
+        .unwrap_or(0)
+        .min(10_000)
+}
+
+fn default_judge_prompt_template(policy: &JudgePolicy) -> String {
+    format!(
+        "Judge each legal benchmark criterion using all-pass semantics. template={} mode={:?} samples={}",
+        policy.prompt_template_id, policy.mode, policy.sample_count
+    )
+}
+
+fn now_ms() -> u64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
+        Err(_) => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        ArtifactManifestRole, CriterionKind, DeliverableKind, JudgeMode, RunMetrics,
+        RunTerminalState, ToolPolicy, TranscriptEvent, TranscriptEventKind,
+        build_output_artifact_manifest,
+    };
+
+    fn task_spec() -> BenchmarkTaskSpec {
+        BenchmarkTaskSpec {
+            schema_version: crate::LEGAL_BENCHMARK_SCHEMA_VERSION,
+            task_id: String::from("legal.eval.mock"),
+            task_version: String::from("v1"),
+            domain: String::from("legal"),
+            practice_area: String::from("contracts"),
+            workflow: String::from("review"),
+            title: String::from("Evaluate memo"),
+            instructions: String::from("Produce a memo."),
+            work_type: String::from("review"),
+            tags: vec![String::from("eval")],
+            source_artifacts: Vec::new(),
+            deliverables: vec![DeliverableSpec {
+                deliverable_id: String::from("memo"),
+                deliverable_kind: DeliverableKind::Markdown,
+                required_path: String::from("memo.md"),
+                description: String::from("Memo"),
+                required: true,
+            }],
+            criteria: vec![
+                CriterionSpec {
+                    criterion_id: String::from("criterion.memo.exists"),
+                    criterion_kind: CriterionKind::DeliverableValidation,
+                    description: String::from("The memo exists."),
+                    weight_bps: Some(5000),
+                    deliverable_ids: vec![String::from("memo")],
+                    source_artifact_ids: Vec::new(),
+                },
+                CriterionSpec {
+                    criterion_id: String::from("criterion.reasoning"),
+                    criterion_kind: CriterionKind::LegalReasoning,
+                    description: String::from("The memo includes legal reasoning."),
+                    weight_bps: Some(5000),
+                    deliverable_ids: vec![String::from("memo")],
+                    source_artifact_ids: Vec::new(),
+                },
+            ],
+            judge_policy: JudgePolicy {
+                mode: JudgeMode::Llm,
+                provider: String::from("mock"),
+                model: String::from("mock-judge"),
+                prompt_template_id: String::from("judge.legal.v1"),
+                prompt_template_hash: String::from("fixture-template-hash"),
+                all_pass_required: true,
+                sample_count: 1,
+            },
+            tool_policy: ToolPolicy {
+                allowed_tools: vec![String::from("write")],
+                network_allowed: false,
+                source_artifacts_read_only: true,
+                max_turns: 4,
+                max_wall_time_seconds: 60,
+            },
+            source_compatibility: None,
+            metadata: Metadata::new(),
+        }
+    }
+
+    fn run_record(task: &BenchmarkTaskSpec, output_manifest: &ArtifactManifest) -> RunRecord {
+        RunRecord {
+            schema_version: crate::LEGAL_BENCHMARK_SCHEMA_VERSION,
+            run_id: String::from("run.eval.mock"),
+            task_id: task.task_id.clone(),
+            task_version: task.task_version.clone(),
+            input_artifact_manifest_hash: String::from("input-hash"),
+            run_config_hash: String::from("config-hash"),
+            output_artifact_manifest_hash: artifact_manifest_digest(output_manifest)
+                .expect("manifest hash"),
+            terminal_state: RunTerminalState::Submitted,
+            transcript: vec![TranscriptEvent {
+                event_index: 0,
+                event_kind: TranscriptEventKind::Assistant,
+                role: Some(String::from("assistant")),
+                content: Some(String::from("submitted")),
+                payload: None,
+                timestamp_ms: now_ms(),
+            }],
+            tool_calls: Vec::new(),
+            metrics: RunMetrics {
+                model_turns: 1,
+                tool_call_count: 0,
+                input_tokens: 10,
+                output_tokens: 5,
+                wall_time_ms: 100,
+                estimated_cost_micro_usd: 12,
+            },
+            extraction_receipt_refs: vec![String::from("extract.1")],
+            metadata: Metadata::new(),
+        }
+    }
+
+    #[test]
+    fn evaluator_scores_completed_run_with_mock_judge() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let output_root = temp.path().join("output");
+        fs::create_dir_all(&output_root).expect("output dir");
+        fs::write(output_root.join("memo.md"), "# Memo\n\nLegal reasoning.\n").expect("memo");
+        let task = task_spec();
+        let artifact = artifact_from_file(
+            "artifact.output.0",
+            ArtifactKind::GeneratedDeliverable,
+            &output_root,
+            output_root.join("memo.md"),
+            DataClassification::BenchmarkConfidential,
+            Some(String::from("test")),
+        )
+        .expect("artifact");
+        let output_manifest = build_output_artifact_manifest(
+            task.task_id.clone(),
+            task.task_version.clone(),
+            "run.eval.mock",
+            vec![artifact],
+        );
+        assert_eq!(output_manifest.manifest_role, ArtifactManifestRole::Output);
+        let run_record = run_record(&task, &output_manifest);
+        let input = LegalBenchmarkEvaluationInput {
+            task_spec: task,
+            run_record,
+            output_artifact_manifest: output_manifest,
+            output_root,
+        };
+        let mut judge = MockLegalBenchmarkJudge::pass();
+        let result = evaluate_legal_benchmark_run(&input, &mut judge).expect("evaluation");
+
+        assert!(result.score_report.all_pass);
+        assert_eq!(result.score_report.criterion_pass_rate_bps, 10_000);
+        assert_eq!(result.score_report.document_coverage_bps, 10_000);
+        assert_eq!(
+            result.score_report.extraction_receipt_refs,
+            vec!["extract.1"]
+        );
+        assert!(result.score_report.failure_diagnostics.is_empty());
+        assert_eq!(result.score_report.criterion_results.len(), 2);
+        assert!(result.score_report_hash.len() == 64);
+    }
+
+    #[test]
+    fn missing_deliverable_fails_deterministic_precheck() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let output_root = temp.path().join("output");
+        fs::create_dir_all(&output_root).expect("output dir");
+        let task = task_spec();
+        let output_manifest = build_output_artifact_manifest(
+            task.task_id.clone(),
+            task.task_version.clone(),
+            "run.eval.missing",
+            Vec::new(),
+        );
+        let run_record = run_record(&task, &output_manifest);
+        let input = LegalBenchmarkEvaluationInput {
+            task_spec: task,
+            run_record,
+            output_artifact_manifest: output_manifest,
+            output_root,
+        };
+        let mut judge = MockLegalBenchmarkJudge::pass();
+        let result = evaluate_legal_benchmark_run(&input, &mut judge).expect("evaluation");
+
+        assert!(!result.score_report.all_pass);
+        assert!(!result.score_report.failure_diagnostics.is_empty());
+        assert_eq!(
+            result.score_report.criterion_results[0].verdict,
+            CriterionVerdict::Fail
+        );
+    }
+}

--- a/crates/psionic-eval/src/lib.rs
+++ b/crates/psionic-eval/src/lib.rs
@@ -12,6 +12,7 @@
 
 mod legal_benchmark;
 mod legal_benchmark_agent;
+mod legal_benchmark_evaluator;
 mod legal_benchmark_extraction;
 mod legal_benchmark_harvey;
 mod legal_benchmark_provider;
@@ -19,6 +20,7 @@ mod legal_benchmark_tools;
 
 pub use legal_benchmark::*;
 pub use legal_benchmark_agent::*;
+pub use legal_benchmark_evaluator::*;
 pub use legal_benchmark_extraction::*;
 pub use legal_benchmark_harvey::*;
 pub use legal_benchmark_provider::*;

--- a/docs/LEGAL_BENCHMARK_ENGINE.md
+++ b/docs/LEGAL_BENCHMARK_ENGINE.md
@@ -180,8 +180,19 @@ and writes `config.json`, `transcript.jsonl`, `metrics.json`,
 `output_artifact_manifest.json`, `extraction_receipts.json`,
 `tool_receipts.json`, `run_record.json`, and `run_receipt.json`.
 
+## Evaluator And Judge Interface
+
+The criterion-scoped evaluator is documented in
+`docs/LEGAL_BENCHMARK_EVALUATOR.md` and implemented in
+`crates/psionic-eval/src/legal_benchmark_evaluator.rs`.
+
+It loads completed task/run/output-manifest artifacts, runs deterministic
+manifest and deliverable prechecks, extracts output text per criterion, calls a
+provider-neutral judge adapter, and emits `ScoreReport` values with all-pass
+status, criterion pass rate, judge provenance, confidence, latency, cost,
+document coverage, failure diagnostics, and extraction receipt refs.
+
 ## Next Work
 
-The next implementation issue is the criterion-scoped evaluator and judge
-interface. It should consume completed run directories and produce score
-reports with criterion provenance.
+The next implementation issue is static report and comparison generation. It
+should consume score reports and run receipts from the runner/evaluator path.

--- a/docs/LEGAL_BENCHMARK_EVALUATOR.md
+++ b/docs/LEGAL_BENCHMARK_EVALUATOR.md
@@ -1,0 +1,67 @@
+# Legal Benchmark Evaluator
+
+> Status: implemented_early.
+
+The criterion-scoped evaluator lives in
+`crates/psionic-eval/src/legal_benchmark_evaluator.rs`. It consumes completed
+Rust agent-run artifacts and produces `ScoreReport` records with deterministic
+prechecks, criterion-level judge provenance, and diagnostics.
+
+## Inputs
+
+`LegalBenchmarkEvaluationInput` binds:
+
+- normalized `BenchmarkTaskSpec`
+- completed `RunRecord`
+- output `ArtifactManifest`
+- output root containing generated deliverables
+
+The evaluator recomputes the output manifest hash and verifies each manifest
+artifact before trusting the run for scoring.
+
+## Deterministic Prechecks
+
+Before calling a judge, the evaluator checks:
+
+- output manifest hash matches the run record
+- required deliverables exist
+- required deliverables are readable
+- deliverable extension matches the declared deliverable kind
+- output artifact hashes, byte sizes, and media types match the manifest
+
+Failures become report diagnostics. Criteria tied to missing or invalid
+deliverables fail through `deterministic_precheck` without spending judge
+tokens.
+
+## Judge Interface
+
+`LegalBenchmarkJudgeAdapter` is provider-neutral. A judge receives
+`LegalBenchmarkJudgeRequest` with:
+
+- criterion spec
+- output text bundle
+- evidence refs
+- prompt template id
+- prompt template hash
+- judge model id
+
+The response records verdict, reasoning, optional confidence, raw response,
+latency, and cost. `MockLegalBenchmarkJudge` supports deterministic CI without
+live provider credentials.
+
+## Score Report
+
+`ScoreReport` now carries:
+
+- all-pass status
+- criterion pass rate
+- run metrics with judge latency and cost included
+- document coverage in basis points
+- failure diagnostics
+- extraction receipt refs
+- criterion result judge model, prompt hash, raw response hash, confidence,
+  latency, and cost
+
+The score report hash is computed with the existing
+`score_report_digest()` helper and can feed static reports, sweep comparisons,
+and Autopilot4 imports.

--- a/fixtures/legal_benchmark/evaluator_mock_score_report.json
+++ b/fixtures/legal_benchmark/evaluator_mock_score_report.json
@@ -1,0 +1,41 @@
+{
+  "schema_version": 1,
+  "score_report_id": "score.run.eval.mock.judge.legal.v1",
+  "run_id": "run.eval.mock",
+  "task_id": "legal.eval.mock",
+  "task_version": "v1",
+  "run_record_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "output_artifact_manifest_hash": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "all_pass": true,
+  "criterion_pass_rate_bps": 10000,
+  "criterion_results": [
+    {
+      "criterion_id": "criterion.memo.exists",
+      "passed": true,
+      "verdict": "pass",
+      "reasoning": "mock judge passed the criterion",
+      "evidence_refs": ["memo"],
+      "judge_model": "mock-judge",
+      "judge_prompt_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+      "raw_response_hash": "dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd",
+      "confidence_bps": 10000,
+      "judge_latency_ms": 1,
+      "judge_cost_micro_usd": 0
+    }
+  ],
+  "metrics": {
+    "model_turns": 1,
+    "tool_call_count": 0,
+    "input_tokens": 10,
+    "output_tokens": 5,
+    "wall_time_ms": 101,
+    "estimated_cost_micro_usd": 12
+  },
+  "document_coverage_bps": 10000,
+  "failure_diagnostics": [],
+  "extraction_receipt_refs": ["extract.1"],
+  "metadata": {
+    "precheck_count": 2,
+    "judge_prompt_template_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+  }
+}


### PR DESCRIPTION
Summary
- Adds criterion-scoped legal benchmark evaluator with deterministic manifest/deliverable prechecks before judge calls.
- Adds provider-neutral judge interface and deterministic mock judge for CI.
- Emits ScoreReport records with all-pass status, criterion pass rate, document coverage, failure diagnostics, judge confidence, judge latency, judge cost, prompt hashes, raw response hashes, and extraction receipt refs.
- Adds evaluator docs and a mock score-report fixture.

Validation
- cargo test -p psionic-eval --no-default-features --lib legal_benchmark_evaluator
- cargo test -p psionic-eval --no-default-features --lib
- cargo test -p psionic-eval --lib legal_benchmark_evaluator
- python3 -m json.tool fixtures/legal_benchmark/evaluator_mock_score_report.json
- git diff --cached --check

Closes #994