### PR TITLE
Add legal benchmark static reports

### DIFF
--- a/crates/psionic-eval/examples/legal_benchmark_report.rs
+++ b/crates/psionic-eval/examples/legal_benchmark_report.rs
@@ -1,0 +1,45 @@
+use std::env;
+use std::error::Error;
+use std::fs;
+use std::io;
+use std::path::PathBuf;
+
+use psionic_eval::{
+    LegalBenchmarkReportInput, ScoreReport, generate_legal_benchmark_static_report,
+};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = env::args().collect::<Vec<_>>();
+    let score_path = args.get(1).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "usage: legal_benchmark_report <score_report.json> <output_dir>",
+        )
+    })?;
+    let output_dir = args.get(2).ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "usage: legal_benchmark_report <score_report.json> <output_dir>",
+        )
+    })?;
+    let output_dir = PathBuf::from(output_dir);
+    fs::create_dir_all(&output_dir)?;
+    let score_report =
+        serde_json::from_slice::<ScoreReport>(&fs::read(PathBuf::from(score_path))?)?;
+    let report = generate_legal_benchmark_static_report(&LegalBenchmarkReportInput {
+        report_id: String::from("legal_benchmark_report"),
+        score_reports: vec![score_report],
+        run_records: Vec::new(),
+        output_manifests: Vec::new(),
+    })?;
+    fs::write(output_dir.join("report.md"), report.markdown)?;
+    fs::write(
+        output_dir.join("autopilot_report.json"),
+        serde_json::to_vec_pretty(&report.autopilot_export)?,
+    )?;
+    fs::write(
+        output_dir.join("failure_clusters.json"),
+        serde_json::to_vec_pretty(&report.autopilot_export.failure_clusters)?,
+    )?;
+    Ok(())
+}

--- a/crates/psionic-eval/src/legal_benchmark_evaluator.rs
+++ b/crates/psionic-eval/src/legal_benchmark_evaluator.rs
@@ -3,17 +3,16 @@
 use std::collections::BTreeSet;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::time::{SystemTime, UNIX_EPOCH};
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use thiserror::Error;
 
 use crate::{
-    ArtifactKind, ArtifactManifest, ArtifactManifestError, BenchmarkTaskSpec, CriterionResult,
-    CriterionSpec, CriterionVerdict, DataClassification, DeliverableKind, DeliverableSpec,
-    JudgePolicy, Metadata, RunRecord, ScoreReport, SourceArtifact, artifact_from_file,
-    artifact_manifest_digest, run_record_digest, score_report_digest, stable_json_digest,
+    ArtifactManifest, ArtifactManifestError, BenchmarkTaskSpec, CriterionResult, CriterionSpec,
+    CriterionVerdict, DeliverableKind, DeliverableSpec, JudgePolicy, Metadata, RunRecord,
+    ScoreReport, SourceArtifact, artifact_from_file, artifact_manifest_digest, run_record_digest,
+    score_report_digest, stable_json_digest,
 };
 
 pub const LEGAL_BENCHMARK_EVALUATOR_SCHEMA_VERSION: u16 = 1;
@@ -472,8 +471,9 @@ fn default_judge_prompt_template(policy: &JudgePolicy) -> String {
     )
 }
 
+#[cfg(test)]
 fn now_ms() -> u64 {
-    match SystemTime::now().duration_since(UNIX_EPOCH) {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
         Ok(duration) => u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
         Err(_) => 0,
     }
@@ -483,8 +483,8 @@ fn now_ms() -> u64 {
 mod tests {
     use super::*;
     use crate::{
-        ArtifactManifestRole, CriterionKind, DeliverableKind, JudgeMode, RunMetrics,
-        RunTerminalState, ToolPolicy, TranscriptEvent, TranscriptEventKind,
+        ArtifactKind, ArtifactManifestRole, CriterionKind, DataClassification, DeliverableKind,
+        JudgeMode, RunMetrics, RunTerminalState, ToolPolicy, TranscriptEvent, TranscriptEventKind,
         build_output_artifact_manifest,
     };
 

--- a/crates/psionic-eval/src/legal_benchmark_reports.rs
+++ b/crates/psionic-eval/src/legal_benchmark_reports.rs
@@ -1,0 +1,558 @@
+//! Static report and import-summary generation for legal benchmark scores.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    ArtifactManifest, ComparisonReport, CriterionResult, CriterionVerdict, Metadata, RunRecord,
+    ScoreReport, comparison_report_digest, score_report_digest, stable_json_digest,
+};
+
+pub const LEGAL_BENCHMARK_REPORT_SCHEMA_VERSION: u16 = 1;
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkReportInput {
+    pub report_id: String,
+    pub score_reports: Vec<ScoreReport>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub run_records: Vec<RunRecord>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub output_manifests: Vec<ArtifactManifest>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkReportAggregate {
+    pub run_count: u64,
+    pub all_pass_count: u64,
+    pub all_pass_rate_bps: u32,
+    pub criterion_pass_rate_bps: u32,
+    pub total_cost_micro_usd: u64,
+    pub total_wall_time_ms: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub document_coverage_bps: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkTaskSummary {
+    pub task_id: String,
+    pub run_count: u64,
+    pub best_all_pass: bool,
+    pub best_criterion_pass_rate_bps: u32,
+    pub latest_score_report_hash: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkModelConfigSummary {
+    pub run_config_hash: String,
+    pub run_count: u64,
+    pub all_pass_rate_bps: u32,
+    pub criterion_pass_rate_bps: u32,
+    pub total_cost_micro_usd: u64,
+    pub total_wall_time_ms: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkFailureCluster {
+    pub cluster_id: String,
+    pub failure_family: String,
+    pub task_ids: Vec<String>,
+    pub criterion_ids: Vec<String>,
+    pub failure_count: u64,
+    pub score_delta_bps: i32,
+    pub repro_command: String,
+    pub affected_modules: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub diagnostics: Vec<String>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkAutopilotReportExport {
+    pub schema_version: u16,
+    pub report_id: String,
+    pub generated_at_ms: u64,
+    pub global: LegalBenchmarkReportAggregate,
+    pub by_task: Vec<LegalBenchmarkTaskSummary>,
+    pub by_model_config: Vec<LegalBenchmarkModelConfigSummary>,
+    pub failure_clusters: Vec<LegalBenchmarkFailureCluster>,
+    pub score_report_hashes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Metadata::is_empty")]
+    pub metadata: Metadata,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkStaticReport {
+    pub markdown: String,
+    pub autopilot_export: LegalBenchmarkAutopilotReportExport,
+    pub comparison_reports: Vec<ComparisonReport>,
+}
+
+pub fn generate_legal_benchmark_static_report(
+    input: &LegalBenchmarkReportInput,
+) -> Result<LegalBenchmarkStaticReport, serde_json::Error> {
+    let global = aggregate_scores(&input.score_reports);
+    let by_task = summarize_by_task(&input.score_reports)?;
+    let by_model_config = summarize_by_model_config(&input.score_reports, &input.run_records);
+    let failure_clusters = failure_clusters(&input.score_reports);
+    let score_report_hashes = input
+        .score_reports
+        .iter()
+        .map(score_report_digest)
+        .collect::<Result<Vec<_>, _>>()?;
+    let comparison_reports = comparison_reports(&input.report_id, &input.score_reports)?;
+    let export = LegalBenchmarkAutopilotReportExport {
+        schema_version: LEGAL_BENCHMARK_REPORT_SCHEMA_VERSION,
+        report_id: input.report_id.clone(),
+        generated_at_ms: now_ms(),
+        global,
+        by_task,
+        by_model_config,
+        failure_clusters,
+        score_report_hashes,
+        metadata: Metadata::new(),
+    };
+    let markdown = render_markdown_report(input, &export, &comparison_reports)?;
+    Ok(LegalBenchmarkStaticReport {
+        markdown,
+        autopilot_export: export,
+        comparison_reports,
+    })
+}
+
+pub fn legal_benchmark_report_export_hash(
+    export: &LegalBenchmarkAutopilotReportExport,
+) -> Result<String, serde_json::Error> {
+    stable_json_digest("psionic.legal_benchmark.report_export.v1", export)
+}
+
+fn aggregate_scores(score_reports: &[ScoreReport]) -> LegalBenchmarkReportAggregate {
+    let run_count = u64::try_from(score_reports.len()).unwrap_or(u64::MAX);
+    let all_pass_count = u64::try_from(
+        score_reports
+            .iter()
+            .filter(|report| report.all_pass)
+            .count(),
+    )
+    .unwrap_or(u64::MAX);
+    let criterion_sum = score_reports
+        .iter()
+        .map(|report| u64::from(report.criterion_pass_rate_bps))
+        .sum::<u64>();
+    let coverage_sum = score_reports
+        .iter()
+        .map(|report| u64::from(report.document_coverage_bps))
+        .sum::<u64>();
+    let total_cost_micro_usd = score_reports
+        .iter()
+        .map(|report| report.metrics.estimated_cost_micro_usd)
+        .sum();
+    let total_wall_time_ms = score_reports
+        .iter()
+        .map(|report| report.metrics.wall_time_ms)
+        .sum();
+    let input_tokens = score_reports
+        .iter()
+        .map(|report| report.metrics.input_tokens)
+        .sum();
+    let output_tokens = score_reports
+        .iter()
+        .map(|report| report.metrics.output_tokens)
+        .sum();
+    LegalBenchmarkReportAggregate {
+        run_count,
+        all_pass_count,
+        all_pass_rate_bps: ratio_bps(all_pass_count, run_count),
+        criterion_pass_rate_bps: average_bps(criterion_sum, run_count),
+        total_cost_micro_usd,
+        total_wall_time_ms,
+        input_tokens,
+        output_tokens,
+        document_coverage_bps: average_bps(coverage_sum, run_count),
+    }
+}
+
+fn summarize_by_task(
+    score_reports: &[ScoreReport],
+) -> Result<Vec<LegalBenchmarkTaskSummary>, serde_json::Error> {
+    let mut by_task = BTreeMap::<String, Vec<&ScoreReport>>::new();
+    for report in score_reports {
+        by_task
+            .entry(report.task_id.clone())
+            .or_default()
+            .push(report);
+    }
+    let mut summaries = Vec::new();
+    for (task_id, reports) in by_task {
+        let Some(latest) = reports.last() else {
+            continue;
+        };
+        let best_criterion_pass_rate_bps = reports
+            .iter()
+            .map(|report| report.criterion_pass_rate_bps)
+            .max()
+            .unwrap_or(0);
+        summaries.push(LegalBenchmarkTaskSummary {
+            task_id,
+            run_count: u64::try_from(reports.len()).unwrap_or(u64::MAX),
+            best_all_pass: reports.iter().any(|report| report.all_pass),
+            best_criterion_pass_rate_bps,
+            latest_score_report_hash: score_report_digest(latest)?,
+        });
+    }
+    Ok(summaries)
+}
+
+fn summarize_by_model_config(
+    score_reports: &[ScoreReport],
+    run_records: &[RunRecord],
+) -> Vec<LegalBenchmarkModelConfigSummary> {
+    let run_config_by_run = run_records
+        .iter()
+        .map(|record| (record.run_id.clone(), record.run_config_hash.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let mut grouped = BTreeMap::<String, Vec<&ScoreReport>>::new();
+    for report in score_reports {
+        let key = run_config_by_run
+            .get(&report.run_id)
+            .cloned()
+            .unwrap_or_else(|| report.run_record_hash.clone());
+        grouped.entry(key).or_default().push(report);
+    }
+    grouped
+        .into_iter()
+        .map(|(run_config_hash, reports)| {
+            let run_count = u64::try_from(reports.len()).unwrap_or(u64::MAX);
+            let all_pass_count =
+                u64::try_from(reports.iter().filter(|report| report.all_pass).count())
+                    .unwrap_or(u64::MAX);
+            let criterion_sum = reports
+                .iter()
+                .map(|report| u64::from(report.criterion_pass_rate_bps))
+                .sum();
+            LegalBenchmarkModelConfigSummary {
+                run_config_hash,
+                run_count,
+                all_pass_rate_bps: ratio_bps(all_pass_count, run_count),
+                criterion_pass_rate_bps: average_bps(criterion_sum, run_count),
+                total_cost_micro_usd: reports
+                    .iter()
+                    .map(|report| report.metrics.estimated_cost_micro_usd)
+                    .sum(),
+                total_wall_time_ms: reports
+                    .iter()
+                    .map(|report| report.metrics.wall_time_ms)
+                    .sum(),
+            }
+        })
+        .collect()
+}
+
+fn failure_clusters(score_reports: &[ScoreReport]) -> Vec<LegalBenchmarkFailureCluster> {
+    let mut grouped = BTreeMap::<String, Vec<(&ScoreReport, &CriterionResult)>>::new();
+    for report in score_reports {
+        for criterion in &report.criterion_results {
+            if criterion.verdict == CriterionVerdict::Pass {
+                continue;
+            }
+            grouped
+                .entry(failure_family(criterion))
+                .or_default()
+                .push((report, criterion));
+        }
+    }
+    grouped
+        .into_iter()
+        .map(|(failure_family, entries)| {
+            let task_ids = entries
+                .iter()
+                .map(|(report, _)| report.task_id.clone())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            let criterion_ids = entries
+                .iter()
+                .map(|(_, criterion)| criterion.criterion_id.clone())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            let diagnostics = entries
+                .iter()
+                .map(|(_, criterion)| criterion.reasoning.clone())
+                .collect::<BTreeSet<_>>()
+                .into_iter()
+                .collect::<Vec<_>>();
+            LegalBenchmarkFailureCluster {
+                cluster_id: format!("failure.{}", stable_label(&failure_family)),
+                failure_family,
+                task_ids,
+                criterion_ids,
+                failure_count: u64::try_from(entries.len()).unwrap_or(u64::MAX),
+                score_delta_bps: -10_000,
+                repro_command: String::from(
+                    "cargo test -p psionic-eval --no-default-features --lib legal_benchmark_reports",
+                ),
+                affected_modules: vec![String::from("psionic-eval/legal_benchmark")],
+                diagnostics,
+            }
+        })
+        .collect()
+}
+
+fn comparison_reports(
+    report_id: &str,
+    score_reports: &[ScoreReport],
+) -> Result<Vec<ComparisonReport>, serde_json::Error> {
+    let mut reports = Vec::new();
+    for window in score_reports.windows(2) {
+        let baseline = &window[0];
+        let candidate = &window[1];
+        let baseline_hash = score_report_digest(baseline)?;
+        let candidate_hash = score_report_digest(candidate)?;
+        let comparison = ComparisonReport {
+            schema_version: crate::LEGAL_BENCHMARK_SCHEMA_VERSION,
+            comparison_report_id: format!(
+                "comparison.{report_id}.{}.{}",
+                stable_label(&baseline.run_id),
+                stable_label(&candidate.run_id)
+            ),
+            comparison_scope: report_id.to_owned(),
+            baseline_score_report_hash: baseline_hash,
+            candidate_score_report_hash: candidate_hash,
+            all_pass_delta_bps: all_pass_bps(candidate) - all_pass_bps(baseline),
+            criterion_pass_rate_delta_bps: i32::try_from(candidate.criterion_pass_rate_bps)
+                .unwrap_or(0)
+                - i32::try_from(baseline.criterion_pass_rate_bps).unwrap_or(0),
+            estimated_cost_delta_micro_usd: i64::try_from(
+                candidate.metrics.estimated_cost_micro_usd,
+            )
+            .unwrap_or(i64::MAX)
+                - i64::try_from(baseline.metrics.estimated_cost_micro_usd).unwrap_or(i64::MAX),
+            wall_time_delta_ms: i64::try_from(candidate.metrics.wall_time_ms).unwrap_or(i64::MAX)
+                - i64::try_from(baseline.metrics.wall_time_ms).unwrap_or(i64::MAX),
+            metadata: Metadata::new(),
+        };
+        let _ = comparison_report_digest(&comparison)?;
+        reports.push(comparison);
+    }
+    Ok(reports)
+}
+
+fn render_markdown_report(
+    input: &LegalBenchmarkReportInput,
+    export: &LegalBenchmarkAutopilotReportExport,
+    comparison_reports: &[ComparisonReport],
+) -> Result<String, serde_json::Error> {
+    let mut markdown = String::new();
+    markdown.push_str(&format!(
+        "# Legal Benchmark Report: {}\n\n",
+        input.report_id
+    ));
+    markdown.push_str("## Global\n\n");
+    markdown.push_str(&format!(
+        "- runs: {}\n- all-pass rate: {} bps\n- criterion pass rate: {} bps\n- document coverage: {} bps\n- cost: {} micro-usd\n- wall time: {} ms\n- tokens: {} input / {} output\n\n",
+        export.global.run_count,
+        export.global.all_pass_rate_bps,
+        export.global.criterion_pass_rate_bps,
+        export.global.document_coverage_bps,
+        export.global.total_cost_micro_usd,
+        export.global.total_wall_time_ms,
+        export.global.input_tokens,
+        export.global.output_tokens,
+    ));
+    markdown.push_str("## Runs\n\n");
+    for report in &input.score_reports {
+        markdown.push_str(&format!(
+            "### {} / {}\n\n- all pass: {}\n- criterion pass rate: {} bps\n- document coverage: {} bps\n- run hash: {}\n- output manifest hash: {}\n- cost: {} micro-usd\n- wall time: {} ms\n\n",
+            report.task_id,
+            report.run_id,
+            report.all_pass,
+            report.criterion_pass_rate_bps,
+            report.document_coverage_bps,
+            report.run_record_hash,
+            report.output_artifact_manifest_hash,
+            report.metrics.estimated_cost_micro_usd,
+            report.metrics.wall_time_ms,
+        ));
+        let missed = report
+            .criterion_results
+            .iter()
+            .filter(|criterion| criterion.verdict != CriterionVerdict::Pass)
+            .collect::<Vec<_>>();
+        if missed.is_empty() {
+            markdown.push_str("All criteria passed.\n\n");
+        } else {
+            markdown.push_str("Missed criteria:\n\n");
+            for criterion in missed {
+                markdown.push_str(&format!(
+                    "- {}: {:?}; {}\n",
+                    criterion.criterion_id, criterion.verdict, criterion.reasoning
+                ));
+            }
+            markdown.push('\n');
+        }
+    }
+    markdown.push_str("## Failure Clusters\n\n");
+    if export.failure_clusters.is_empty() {
+        markdown.push_str("No failure clusters.\n\n");
+    } else {
+        for cluster in &export.failure_clusters {
+            markdown.push_str(&format!(
+                "- {}: {} failures across {} tasks; repro `{}`\n",
+                cluster.failure_family,
+                cluster.failure_count,
+                cluster.task_ids.len(),
+                cluster.repro_command
+            ));
+        }
+        markdown.push('\n');
+    }
+    markdown.push_str("## Comparisons\n\n");
+    if comparison_reports.is_empty() {
+        markdown.push_str("No pairwise comparisons.\n");
+    } else {
+        for comparison in comparison_reports {
+            markdown.push_str(&format!(
+                "- {}: all-pass delta {} bps, criterion delta {} bps, cost delta {} micro-usd, wall-time delta {} ms\n",
+                comparison.comparison_report_id,
+                comparison.all_pass_delta_bps,
+                comparison.criterion_pass_rate_delta_bps,
+                comparison.estimated_cost_delta_micro_usd,
+                comparison.wall_time_delta_ms
+            ));
+        }
+    }
+    let export_hash = legal_benchmark_report_export_hash(export)?;
+    markdown.push_str(&format!("\n\nExport hash: `{export_hash}`\n"));
+    Ok(markdown)
+}
+
+fn failure_family(criterion: &CriterionResult) -> String {
+    match criterion.verdict {
+        CriterionVerdict::Fail => {
+            if criterion.judge_model == "deterministic_precheck" {
+                String::from("deterministic_precheck")
+            } else {
+                String::from("judge_fail")
+            }
+        }
+        CriterionVerdict::Ambiguous => String::from("judge_ambiguous"),
+        CriterionVerdict::NotEvaluated => String::from("not_evaluated"),
+        CriterionVerdict::Pass => String::from("pass"),
+    }
+}
+
+fn ratio_bps(numerator: u64, denominator: u64) -> u32 {
+    if denominator == 0 {
+        return 0;
+    }
+    u32::try_from((numerator * 10_000) / denominator).unwrap_or(0)
+}
+
+fn average_bps(sum: u64, count: u64) -> u32 {
+    if count == 0 {
+        0
+    } else {
+        u32::try_from(sum / count).unwrap_or(0)
+    }
+}
+
+fn all_pass_bps(report: &ScoreReport) -> i32 {
+    if report.all_pass { 10_000 } else { 0 }
+}
+
+fn stable_label(value: &str) -> String {
+    value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '.'
+            }
+        })
+        .collect()
+}
+
+fn now_ms() -> u64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => u64::try_from(duration.as_millis()).unwrap_or(u64::MAX),
+        Err(_) => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CriterionResult, RunMetrics};
+
+    fn fixture_score_report() -> ScoreReport {
+        serde_json::from_str(include_str!(
+            "../../../fixtures/legal_benchmark/evaluator_mock_score_report.json"
+        ))
+        .expect("score fixture parses")
+    }
+
+    #[test]
+    fn report_export_summarizes_fixture_score_report() {
+        let score = fixture_score_report();
+        let input = LegalBenchmarkReportInput {
+            report_id: String::from("report.mock"),
+            score_reports: vec![score],
+            run_records: Vec::new(),
+            output_manifests: Vec::new(),
+        };
+        let report = generate_legal_benchmark_static_report(&input).expect("report");
+
+        assert!(report.markdown.contains("Legal Benchmark Report"));
+        assert_eq!(report.autopilot_export.global.run_count, 1);
+        assert_eq!(report.autopilot_export.global.all_pass_rate_bps, 10_000);
+        assert_eq!(report.autopilot_export.by_task.len(), 1);
+        assert!(report.autopilot_export.failure_clusters.is_empty());
+        assert_eq!(report.autopilot_export.score_report_hashes.len(), 1);
+        assert!(legal_benchmark_report_export_hash(&report.autopilot_export).is_ok());
+    }
+
+    #[test]
+    fn failure_cluster_export_groups_missed_criteria() {
+        let mut score = fixture_score_report();
+        score.all_pass = false;
+        score.criterion_pass_rate_bps = 0;
+        score.criterion_results = vec![CriterionResult {
+            criterion_id: String::from("criterion.reasoning"),
+            passed: false,
+            verdict: CriterionVerdict::Fail,
+            reasoning: String::from("missing legal reasoning"),
+            evidence_refs: vec![String::from("memo")],
+            judge_model: String::from("mock-judge"),
+            judge_prompt_hash: String::from("prompt-hash"),
+            raw_response_hash: String::from("raw-hash"),
+            confidence_bps: Some(9000),
+            judge_latency_ms: Some(2),
+            judge_cost_micro_usd: Some(1),
+        }];
+        score.metrics = RunMetrics {
+            model_turns: 1,
+            tool_call_count: 0,
+            input_tokens: 10,
+            output_tokens: 5,
+            wall_time_ms: 10,
+            estimated_cost_micro_usd: 1,
+        };
+        let input = LegalBenchmarkReportInput {
+            report_id: String::from("report.fail"),
+            score_reports: vec![score],
+            run_records: Vec::new(),
+            output_manifests: Vec::new(),
+        };
+        let report = generate_legal_benchmark_static_report(&input).expect("report");
+
+        assert_eq!(report.autopilot_export.failure_clusters.len(), 1);
+        assert_eq!(
+            report.autopilot_export.failure_clusters[0].failure_family,
+            "judge_fail"
+        );
+        assert!(report.markdown.contains("Missed criteria"));
+    }
+}

--- a/crates/psionic-eval/src/lib.rs
+++ b/crates/psionic-eval/src/lib.rs
@@ -16,6 +16,7 @@ mod legal_benchmark_evaluator;
 mod legal_benchmark_extraction;
 mod legal_benchmark_harvey;
 mod legal_benchmark_provider;
+mod legal_benchmark_reports;
 mod legal_benchmark_tools;
 
 pub use legal_benchmark::*;
@@ -24,6 +25,7 @@ pub use legal_benchmark_evaluator::*;
 pub use legal_benchmark_extraction::*;
 pub use legal_benchmark_harvey::*;
 pub use legal_benchmark_provider::*;
+pub use legal_benchmark_reports::*;
 pub use legal_benchmark_tools::*;
 
 #[cfg(feature = "full")]

--- a/docs/LEGAL_BENCHMARK_ENGINE.md
+++ b/docs/LEGAL_BENCHMARK_ENGINE.md
@@ -192,7 +192,20 @@ provider-neutral judge adapter, and emits `ScoreReport` values with all-pass
 status, criterion pass rate, judge provenance, confidence, latency, cost,
 document coverage, failure diagnostics, and extraction receipt refs.
 
+## Static Reports
+
+Static reporting is documented in `docs/LEGAL_BENCHMARK_REPORTS.md` and
+implemented in `crates/psionic-eval/src/legal_benchmark_reports.rs`.
+
+It generates Markdown reports for humans plus stable Autopilot4 import JSON
+with global, per-task, per-model-config, comparison, and failure-cluster
+summaries. The example command
+`cargo run -p psionic-eval --example legal_benchmark_report -- <score.json> <out-dir>`
+writes `report.md`, `autopilot_report.json`, and `failure_clusters.json`
+without live provider credentials.
+
 ## Next Work
 
-The next implementation issue is static report and comparison generation. It
-should consume score reports and run receipts from the runner/evaluator path.
+The next implementation issue is resumable sweep orchestration. It should run
+task/model slices, call the runner/evaluator/report path, and emit sweep
+manifests for Autopilot4 import.

--- a/docs/LEGAL_BENCHMARK_REPORTS.md
+++ b/docs/LEGAL_BENCHMARK_REPORTS.md
@@ -1,0 +1,54 @@
+# Legal Benchmark Reports
+
+> Status: implemented_early.
+
+The static report generator lives in
+`crates/psionic-eval/src/legal_benchmark_reports.rs`. It converts score
+reports into human-readable Markdown and stable machine-readable JSON for
+Autopilot4 import.
+
+## Outputs
+
+The generator produces:
+
+- Markdown run report
+- `LegalBenchmarkAutopilotReportExport`
+- per-task summaries
+- per-model-config summaries
+- pairwise comparison reports
+- failure cluster exports
+
+Reports include all-pass state, missed criteria, judge reasoning summaries,
+artifact/run hashes, cost, latency, token usage, document coverage, extraction
+receipt refs, and failure diagnostics.
+
+## Failure Clusters
+
+Failure clusters group missed criteria by family:
+
+- `deterministic_precheck`
+- `judge_fail`
+- `judge_ambiguous`
+- `not_evaluated`
+
+Each cluster records task ids, criterion ids, failure count, score delta,
+affected modules, diagnostics, and a repro command. Autopilot4 can import the
+JSON directly for dashboards, Work Orders, and issue generation.
+
+## Command
+
+The checked example command writes static artifacts from one score report:
+
+```bash
+cargo run -p psionic-eval --example legal_benchmark_report -- \
+  fixtures/legal_benchmark/evaluator_mock_score_report.json \
+  /tmp/legal-benchmark-report
+```
+
+It writes:
+
+- `/tmp/legal-benchmark-report/report.md`
+- `/tmp/legal-benchmark-report/autopilot_report.json`
+- `/tmp/legal-benchmark-report/failure_clusters.json`
+
+The command does not require live provider credentials.

--- a/fixtures/legal_benchmark/report_export_mock.json
+++ b/fixtures/legal_benchmark/report_export_mock.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": 1,
+  "report_id": "report.mock",
+  "generated_at_ms": 1,
+  "global": {
+    "run_count": 1,
+    "all_pass_count": 1,
+    "all_pass_rate_bps": 10000,
+    "criterion_pass_rate_bps": 10000,
+    "total_cost_micro_usd": 12,
+    "total_wall_time_ms": 101,
+    "input_tokens": 10,
+    "output_tokens": 5,
+    "document_coverage_bps": 10000
+  },
+  "by_task": [
+    {
+      "task_id": "legal.eval.mock",
+      "run_count": 1,
+      "best_all_pass": true,
+      "best_criterion_pass_rate_bps": 10000,
+      "latest_score_report_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    }
+  ],
+  "by_model_config": [
+    {
+      "run_config_hash": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "run_count": 1,
+      "all_pass_rate_bps": 10000,
+      "criterion_pass_rate_bps": 10000,
+      "total_cost_micro_usd": 12,
+      "total_wall_time_ms": 101
+    }
+  ],
+  "failure_clusters": [],
+  "score_report_hashes": [
+    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  ]
+}


### PR DESCRIPTION
Summary
- Adds static legal benchmark report generation with Markdown, Autopilot4 import JSON, per-task summaries, per-model-config summaries, pairwise comparisons, and failure clusters.
- Adds a report example command that writes report.md, autopilot_report.json, and failure_clusters.json from a score report fixture.
- Adds docs and a report export fixture.
- Cleans up default-build evaluator warnings found while compiling the report command.

Validation
- cargo test -p psionic-eval --no-default-features --lib legal_benchmark_reports
- cargo test -p psionic-eval --no-default-features --lib
- cargo test -p psionic-eval --lib legal_benchmark_reports
- cargo run -q -p psionic-eval --example legal_benchmark_report -- fixtures/legal_benchmark/evaluator_mock_score_report.json /tmp/psionic-legal-report-fixture
- test -s /tmp/psionic-legal-report-fixture/report.md
- test -s /tmp/psionic-legal-report-fixture/autopilot_report.json
- test -s /tmp/psionic-legal-report-fixture/failure_clusters.json
- python3 -m json.tool fixtures/legal_benchmark/report_export_mock.json
- python3 -m json.tool /tmp/psionic-legal-report-fixture/autopilot_report.json
- git diff --cached --check

Closes #995