### PR TITLE
Add legal benchmark CI checks

### DIFF
--- a/crates/psionic-eval/src/legal_benchmark_ci.rs
+++ b/crates/psionic-eval/src/legal_benchmark_ci.rs
@@ -1,0 +1,152 @@
+//! CI-oriented golden checks for the legal benchmark compatibility layer.
+
+use std::fs;
+
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+
+use crate::{
+    ArtifactManifest, ArtifactManifestRole, BenchmarkTaskSpec, LegalBenchmarkPathRoot,
+    LegalBenchmarkReportInput, LegalBenchmarkToolInput, LegalBenchmarkToolWorkspace, RunRecord,
+    RunTerminalState, ScoreReport, execute_legal_benchmark_tool,
+    generate_legal_benchmark_static_report, run_legal_benchmark_sweep,
+};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+struct HarveyCorpusMetadata {
+    schema_version: u16,
+    upstream_suite: String,
+    upstream_repo: String,
+    audited_commit: String,
+    tasks: u64,
+    practice_areas: u64,
+    criteria: u64,
+    source_documents: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+struct MinimalTaskBundle {
+    task_spec: BenchmarkTaskSpec,
+    input_manifest: ArtifactManifest,
+    output_manifest: ArtifactManifest,
+    run_record: RunRecord,
+    score_report: ScoreReport,
+}
+
+#[test]
+fn harvey_corpus_metadata_pins_audited_counts() {
+    let metadata: HarveyCorpusMetadata = serde_json::from_str(include_str!(
+        "../../../fixtures/legal_benchmark/harvey_corpus_metadata.json"
+    ))
+    .expect("metadata fixture parses");
+    assert_eq!(metadata.upstream_suite, "harvey_labs");
+    assert_eq!(metadata.audited_commit, "5aa41694");
+    assert_eq!(metadata.tasks, 1251);
+    assert_eq!(metadata.practice_areas, 24);
+    assert_eq!(metadata.criteria, 74990);
+    assert_eq!(metadata.source_documents, 9537);
+}
+
+#[test]
+fn minimal_normalization_snapshot_stays_stable() {
+    let bundle: MinimalTaskBundle = serde_json::from_str(include_str!(
+        "../../../fixtures/legal_benchmark/minimal_task_bundle.json"
+    ))
+    .expect("minimal bundle parses");
+    let snapshot: Value = serde_json::from_str(include_str!(
+        "../../../fixtures/legal_benchmark/normalization_snapshot_minimal.json"
+    ))
+    .expect("snapshot parses");
+    let actual = json!({
+        "schema_version": 1,
+        "task_id": bundle.task_spec.task_id,
+        "task_version": bundle.task_spec.task_version,
+        "domain": bundle.task_spec.domain,
+        "practice_area": bundle.task_spec.practice_area,
+        "workflow": bundle.task_spec.workflow,
+        "source_artifact_count": bundle.task_spec.source_artifacts.len(),
+        "deliverable_count": bundle.task_spec.deliverables.len(),
+        "criterion_count": bundle.task_spec.criteria.len(),
+        "input_manifest_role": manifest_role(&bundle.input_manifest),
+        "output_manifest_role": manifest_role(&bundle.output_manifest),
+        "run_terminal_state": terminal_state(&bundle.run_record),
+        "score_all_pass": bundle.score_report.all_pass,
+        "score_criterion_pass_rate_bps": bundle.score_report.criterion_pass_rate_bps,
+    });
+    assert_eq!(actual, snapshot);
+}
+
+#[cfg(unix)]
+#[test]
+fn sandbox_path_safety_rejects_symlink_escape() {
+    let temp = tempfile::tempdir().expect("tempdir");
+    let documents = temp.path().join("documents");
+    let workspace = temp.path().join("workspace");
+    let output = temp.path().join("output");
+    let outside = temp.path().join("outside");
+    fs::create_dir_all(&documents).expect("documents");
+    fs::create_dir_all(&workspace).expect("workspace");
+    fs::create_dir_all(&output).expect("output");
+    fs::create_dir_all(&outside).expect("outside");
+    fs::write(outside.join("secret.txt"), "outside").expect("outside file");
+    std::os::unix::fs::symlink(outside.join("secret.txt"), workspace.join("escape.txt"))
+        .expect("symlink");
+    let workspace = LegalBenchmarkToolWorkspace::new(&documents, &workspace, &output);
+    let execution = execute_legal_benchmark_tool(
+        &workspace,
+        LegalBenchmarkToolInput::Read {
+            root: LegalBenchmarkPathRoot::Workspace,
+            relative_path: String::from("escape.txt"),
+            prefer_extracted: false,
+        },
+    );
+    assert!(execution.receipt.failure_kind.is_some());
+}
+
+#[test]
+fn mock_run_eval_report_and_sweep_fixtures_do_not_need_provider_keys() {
+    let score_report: ScoreReport = serde_json::from_str(include_str!(
+        "../../../fixtures/legal_benchmark/evaluator_mock_score_report.json"
+    ))
+    .expect("score report parses");
+    let report = generate_legal_benchmark_static_report(&LegalBenchmarkReportInput {
+        report_id: String::from("ci.mock"),
+        score_reports: vec![score_report],
+        run_records: Vec::new(),
+        output_manifests: Vec::new(),
+    })
+    .expect("report generation");
+    assert_eq!(report.autopilot_export.global.run_count, 1);
+
+    let sweep_config = serde_json::from_str(include_str!(
+        "../../../fixtures/legal_benchmark/sweep_smoke_config.json"
+    ))
+    .expect("sweep config parses");
+    let mut executor = crate::MockLegalBenchmarkSweepExecutor::default();
+    let manifest =
+        run_legal_benchmark_sweep(&sweep_config, None, &mut executor).expect("sweep manifest");
+    assert_eq!(manifest.total_jobs, 4);
+    assert_eq!(manifest.failed_jobs, 0);
+}
+
+fn manifest_role(manifest: &ArtifactManifest) -> &'static str {
+    match manifest.manifest_role {
+        ArtifactManifestRole::Input => "input",
+        ArtifactManifestRole::Output => "output",
+        ArtifactManifestRole::Derived => "derived",
+    }
+}
+
+fn terminal_state(run_record: &RunRecord) -> &'static str {
+    match run_record.terminal_state {
+        RunTerminalState::Submitted => "submitted",
+        RunTerminalState::NoToolCalls => "no_tool_calls",
+        RunTerminalState::MaxTurns => "max_turns",
+        RunTerminalState::MaxTokens => "max_tokens",
+        RunTerminalState::ContextOverflow => "context_overflow",
+        RunTerminalState::ProviderFailure => "provider_failure",
+        RunTerminalState::SandboxFailure => "sandbox_failure",
+        RunTerminalState::PolicyFailure => "policy_failure",
+        RunTerminalState::InternalError => "internal_error",
+    }
+}

--- a/crates/psionic-eval/src/legal_benchmark_tools.rs
+++ b/crates/psionic-eval/src/legal_benchmark_tools.rs
@@ -1088,6 +1088,15 @@ fn resolve_existing_path(
     if !path.exists() {
         return Err("path does not exist".to_string());
     }
+    let canonical_root = root_path(workspace, root)
+        .canonicalize()
+        .map_err(|error| format!("failed to canonicalize root: {error}"))?;
+    let canonical_path = path
+        .canonicalize()
+        .map_err(|error| format!("failed to canonicalize path: {error}"))?;
+    if !canonical_path.starts_with(canonical_root.as_path()) {
+        return Err("path escapes selected root".to_string());
+    }
     Ok(path)
 }
 

--- a/crates/psionic-eval/src/lib.rs
+++ b/crates/psionic-eval/src/lib.rs
@@ -12,6 +12,8 @@
 
 mod legal_benchmark;
 mod legal_benchmark_agent;
+#[cfg(test)]
+mod legal_benchmark_ci;
 mod legal_benchmark_evaluator;
 mod legal_benchmark_extraction;
 mod legal_benchmark_harvey;

--- a/docs/LEGAL_BENCHMARK_CI.md
+++ b/docs/LEGAL_BENCHMARK_CI.md
@@ -1,0 +1,34 @@
+# Legal Benchmark CI Checks
+
+> Status: implemented_early.
+
+The repo-native legal benchmark check target is:
+
+```bash
+scripts/check-legal-benchmark-ci.sh
+```
+
+It requires no live model provider credentials.
+
+## Coverage
+
+The check script runs:
+
+- Harvey corpus metadata fixture checks
+- minimal normalized task snapshot checks
+- sandbox traversal and symlink escape checks
+- mock report generation checks
+- mock sweep manifest checks
+- JSON validation for the legal benchmark fixtures used by the runner,
+  evaluator, report, and sweep path
+
+The audited Harvey corpus fixture pins:
+
+- commit `5aa41694`
+- 1,251 tasks
+- 24 practice areas
+- 74,990 criteria
+- 9,537 source documents
+
+If upstream corpus counts or normalization output intentionally change, update
+the fixture in the same PR as the compatibility change.

--- a/docs/LEGAL_BENCHMARK_ENGINE.md
+++ b/docs/LEGAL_BENCHMARK_ENGINE.md
@@ -214,8 +214,18 @@ wall-time, token, and failure budgets, keeps going through individual
 task/model failures, and emits a manifest with skipped, resumed, succeeded,
 failed, blocked, and budget-exhausted job states for Autopilot4 import.
 
+## CI And Golden Fixtures
+
+Repo-native compatibility checks are documented in
+`docs/LEGAL_BENCHMARK_CI.md` and run with
+`scripts/check-legal-benchmark-ci.sh`.
+
+The check target pins the audited Harvey corpus metadata, verifies the minimal
+normalization snapshot, covers sandbox traversal and symlink escape behavior,
+and exercises mock report and sweep fixtures without live provider credentials.
+
 ## Next Work
 
-The next implementation issue is Harvey parity CI and golden corpus checks. It
-should pin the audited corpus shape and run mock runner/evaluator/report/sweep
-fixtures without live provider credentials.
+The next implementation issue is high-score legal document tooling. It should
+improve document inventory, evidence coverage, and deliverable validation
+without exposing hidden rubric data.

--- a/fixtures/legal_benchmark/harvey_corpus_metadata.json
+++ b/fixtures/legal_benchmark/harvey_corpus_metadata.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": 1,
+  "upstream_suite": "harvey_labs",
+  "upstream_repo": "https://github.com/harveyai/harvey-labs",
+  "audited_commit": "5aa41694",
+  "tasks": 1251,
+  "practice_areas": 24,
+  "criteria": 74990,
+  "source_documents": 9537
+}

--- a/fixtures/legal_benchmark/normalization_snapshot_minimal.json
+++ b/fixtures/legal_benchmark/normalization_snapshot_minimal.json
@@ -1,0 +1,16 @@
+{
+  "schema_version": 1,
+  "task_id": "legal.minimal.contract_review.v1",
+  "task_version": "2026-05-19",
+  "domain": "legal",
+  "practice_area": "commercial_contracts",
+  "workflow": "review",
+  "source_artifact_count": 1,
+  "deliverable_count": 1,
+  "criterion_count": 2,
+  "input_manifest_role": "input",
+  "output_manifest_role": "output",
+  "run_terminal_state": "submitted",
+  "score_all_pass": true,
+  "score_criterion_pass_rate_bps": 10000
+}

--- a/scripts/check-legal-benchmark-ci.sh
+++ b/scripts/check-legal-benchmark-ci.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+cargo test -p psionic-eval --no-default-features --lib legal_benchmark_ci
+cargo test -p psionic-eval --no-default-features --lib legal_benchmark_reports
+cargo test -p psionic-eval --no-default-features --lib legal_benchmark_sweeps
+
+python3 -m json.tool fixtures/legal_benchmark/harvey_corpus_metadata.json >/dev/null
+python3 -m json.tool fixtures/legal_benchmark/normalization_snapshot_minimal.json >/dev/null
+python3 -m json.tool fixtures/legal_benchmark/evaluator_mock_score_report.json >/dev/null
+python3 -m json.tool fixtures/legal_benchmark/report_export_mock.json >/dev/null
+python3 -m json.tool fixtures/legal_benchmark/sweep_smoke_config.json >/dev/null


### PR DESCRIPTION
Summary:
- Adds repo-native legal benchmark CI check script with no live provider credentials.
- Adds Harvey corpus metadata fixture and minimal normalization snapshot fixture.
- Adds test-only CI module covering corpus counts, normalization snapshot, symlink sandbox escape, mock report, and mock sweep.
- Tightens tool path resolver to reject existing symlink escapes.

Validation:
- scripts/check-legal-benchmark-ci.sh
- cargo test -p psionic-eval --no-default-features --lib
- cargo test -p psionic-eval --lib legal_benchmark_ci
- git diff --cached --check

Closes #997