### PR TITLE
Add legal benchmark coverage tracker

### DIFF
--- a/crates/psionic-eval/src/legal_benchmark.rs
+++ b/crates/psionic-eval/src/legal_benchmark.rs
@@ -396,6 +396,9 @@ pub struct RunRecord {
     /// Extraction receipt ids or hashes retained by this run.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extraction_receipt_refs: Vec<String>,
+    /// Criterion-adjacent coverage state captured during the run.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage_snapshot: Option<CoverageSnapshot>,
     /// Additional owned metadata.
     #[serde(default, skip_serializing_if = "Metadata::is_empty")]
     pub metadata: Metadata,
@@ -506,6 +509,178 @@ pub struct RunMetrics {
     pub estimated_cost_micro_usd: u64,
 }
 
+/// Policy mode for agent-visible coverage guidance.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CoverageMode {
+    /// No rubric-derived hints are visible to the running agent.
+    Integrity,
+    /// Policy-approved derived checklist items may be visible for training.
+    HillClimb,
+}
+
+/// One policy-approved derived checklist item.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DerivedChecklistItem {
+    /// Stable checklist item id.
+    pub item_id: String,
+    /// Agent-visible checklist text.
+    pub prompt: String,
+    /// Policy or artifact source for this derived item.
+    pub source: String,
+    /// Whether the item is allowed in model-visible training prompts.
+    pub agent_visible: bool,
+}
+
+/// Checklist payload that can be safely rendered to the running agent.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AgentVisibleChecklist {
+    /// Coverage mode used to construct the checklist.
+    pub mode: CoverageMode,
+    /// Policy-approved items visible to the agent.
+    pub items: Vec<DerivedChecklistItem>,
+    /// Whether hidden rubric criteria were exposed.
+    pub hidden_criteria_visible: bool,
+}
+
+/// Per-document coverage state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DocumentCoverageEntry {
+    /// Source artifact id when known.
+    pub artifact_id: String,
+    /// Relative document path.
+    pub relative_path: String,
+    /// Whether the agent discovered the document.
+    pub discovered: bool,
+    /// Whether the agent read the document.
+    pub read: bool,
+    /// Whether extracted text was used instead of raw bytes.
+    pub used_extracted_text: bool,
+}
+
+/// One extracted fact or candidate fact trace.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct FactCoverageEntry {
+    /// Stable fact id.
+    pub fact_id: String,
+    /// Source artifact id or relative path.
+    pub source_ref: String,
+    /// Hash of the extracted text span or summary.
+    pub text_hash: String,
+    /// Extraction mechanism.
+    pub method: String,
+}
+
+/// One evidence reference captured by a tool or self-check.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EvidenceCoverageEntry {
+    /// Stable evidence id.
+    pub evidence_id: String,
+    /// Source artifact id or relative path.
+    pub source_ref: String,
+    /// Optional line number or page label.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub locator: Option<String>,
+    /// Hash of the evidence span.
+    pub span_hash: String,
+}
+
+/// Deliverable drafting coverage state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DeliverableSectionCoverage {
+    /// Deliverable id when matched to the task spec.
+    pub deliverable_id: String,
+    /// Output or workspace path touched by the agent.
+    pub relative_path: String,
+    /// Section or draft id.
+    pub section_id: String,
+    /// Whether the section was drafted or edited.
+    pub drafted: bool,
+}
+
+/// Validation coverage state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ValidationCoverageEntry {
+    /// Stable validation id.
+    pub validation_id: String,
+    /// Validation target such as a deliverable id or path.
+    pub target_ref: String,
+    /// Whether validation passed.
+    pub passed: bool,
+    /// Human-readable validation summary.
+    pub detail: String,
+}
+
+/// Self-check coverage state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SelfCheckCoverageEntry {
+    /// Stable self-check id.
+    pub self_check_id: String,
+    /// Area being checked.
+    pub area: String,
+    /// Self-check outcome.
+    pub outcome: String,
+}
+
+/// Criterion-adjacent coverage snapshot captured without exposing hidden rubric
+/// criteria to the model in integrity mode.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CoverageSnapshot {
+    /// Schema version for coverage snapshots.
+    pub schema_version: u16,
+    /// Policy mode used for the run.
+    pub mode: CoverageMode,
+    /// Whether hidden criteria were included in model-visible messages.
+    pub hidden_criteria_visible: bool,
+    /// Agent-visible derived checklist items.
+    pub derived_checklist_items: Vec<DerivedChecklistItem>,
+    /// Documents discovered or read by the agent.
+    pub documents: Vec<DocumentCoverageEntry>,
+    /// Facts extracted from source documents.
+    pub facts: Vec<FactCoverageEntry>,
+    /// Evidence spans captured during the run.
+    pub evidence_refs: Vec<EvidenceCoverageEntry>,
+    /// Deliverable sections drafted or edited.
+    pub deliverable_sections: Vec<DeliverableSectionCoverage>,
+    /// Validations run before scoring.
+    pub validations: Vec<ValidationCoverageEntry>,
+    /// Agent self-check outcomes.
+    pub self_checks: Vec<SelfCheckCoverageEntry>,
+}
+
+/// Failure class after missed criteria are compared to coverage state.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CriterionFailureClass {
+    /// The agent did not discover or read required source material.
+    CoverageGap,
+    /// The agent read source material but did not extract usable facts/evidence.
+    ExtractionGap,
+    /// The agent extracted relevant material but did not draft the target output.
+    DraftingGap,
+    /// The agent had apparent coverage but reasoned or applied law incorrectly.
+    ReasoningGap,
+    /// The criterion was not a failure.
+    Passed,
+}
+
+/// Post-judge comparison between a missed criterion and run coverage.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CriterionCoverageFailure {
+    /// Criterion id.
+    pub criterion_id: String,
+    /// Failure classification.
+    pub failure_class: CriterionFailureClass,
+    /// Source artifacts that were expected but not read.
+    pub missing_source_artifact_ids: Vec<String>,
+    /// Deliverables that were expected but not drafted.
+    pub missing_deliverable_ids: Vec<String>,
+    /// Evidence ids considered for this comparison.
+    pub evidence_refs: Vec<String>,
+    /// Human-readable diagnostic.
+    pub diagnostic: String,
+}
+
 /// Result for one criterion.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CriterionResult {
@@ -584,6 +759,12 @@ pub struct ScoreReport {
     /// Extraction receipt ids or hashes considered by the scorer.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extraction_receipt_refs: Vec<String>,
+    /// Coverage snapshot considered by the scorer.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub coverage_snapshot: Option<CoverageSnapshot>,
+    /// Post-judge failure classifications derived from coverage state.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub failure_comparisons: Vec<CriterionCoverageFailure>,
     /// Additional owned metadata.
     #[serde(default, skip_serializing_if = "Metadata::is_empty")]
     pub metadata: Metadata,

--- a/crates/psionic-eval/src/legal_benchmark_agent.rs
+++ b/crates/psionic-eval/src/legal_benchmark_agent.rs
@@ -20,9 +20,9 @@ use crate::{
     ModelAdapterError, ModelAdapterFailureKind, ModelMessage, ModelMessageRole, ModelRequest,
     ModelResponse, ModelStopReason, ModelToolCall, RunConfig, RunMetrics, RunRecord,
     RunTerminalState, SourceArtifact, ToolCallRecord, ToolResultMessage, TranscriptEvent,
-    TranscriptEventKind, artifact_from_file, artifact_manifest_digest,
-    build_output_artifact_manifest, execute_legal_benchmark_tool, run_config_digest,
-    run_record_digest, stable_json_digest, task_spec_digest, transcript_digest,
+    TranscriptEventKind, agent_visible_checklist, artifact_from_file, artifact_manifest_digest,
+    build_coverage_snapshot, build_output_artifact_manifest, execute_legal_benchmark_tool,
+    run_config_digest, run_record_digest, stable_json_digest, task_spec_digest, transcript_digest,
 };
 
 pub const LEGAL_BENCHMARK_AGENT_SCHEMA_VERSION: u16 = 1;
@@ -278,6 +278,13 @@ where
         output_artifacts,
     );
     let output_manifest_hash = artifact_manifest_digest(&output_manifest)?;
+    let coverage_snapshot = build_coverage_snapshot(
+        &request.task_spec,
+        &request.run_config,
+        &tool_calls,
+        &transcript,
+        &output_manifest,
+    )?;
     let run_record = RunRecord {
         schema_version: crate::LEGAL_BENCHMARK_SCHEMA_VERSION,
         run_id: run_id.clone(),
@@ -291,6 +298,7 @@ where
         tool_calls,
         metrics,
         extraction_receipt_refs: request.extraction_receipt_refs.clone(),
+        coverage_snapshot: Some(coverage_snapshot),
         metadata: Metadata::new(),
     };
     let run_receipt = LegalBenchmarkRunReceipt {
@@ -385,12 +393,12 @@ pub fn legal_benchmark_user_prompt(request: &LegalBenchmarkAgentRunRequest) -> S
             deliverable.deliverable_id, deliverable.required_path, deliverable.description
         ));
     }
-    prompt.push_str("\nCriteria:\n");
-    for criterion in &request.task_spec.criteria {
-        prompt.push_str(&format!(
-            "- {}: {}\n",
-            criterion.criterion_id, criterion.description
-        ));
+    let checklist = agent_visible_checklist(&request.run_config);
+    if !checklist.items.is_empty() {
+        prompt.push_str("\nApproved checklist:\n");
+        for item in checklist.items {
+            prompt.push_str(&format!("- {}: {}\n", item.item_id, item.prompt));
+        }
     }
     prompt
 }
@@ -906,6 +914,16 @@ mod tests {
         .expect("run record json");
         assert_eq!(decoded.terminal_state, RunTerminalState::Submitted);
         assert_eq!(decoded.extraction_receipt_refs, vec!["extract.mock.1"]);
+        let coverage = decoded.coverage_snapshot.expect("coverage snapshot");
+        assert!(!coverage.hidden_criteria_visible);
+        assert_eq!(coverage.deliverable_sections.len(), 2);
+        let user_prompt = decoded
+            .transcript
+            .iter()
+            .find(|event| event.event_kind == TranscriptEventKind::User)
+            .and_then(|event| event.content.as_deref())
+            .expect("user prompt");
+        assert!(!user_prompt.contains("The memo exists."));
     }
 
     #[test]

--- a/crates/psionic-eval/src/legal_benchmark_coverage.rs
+++ b/crates/psionic-eval/src/legal_benchmark_coverage.rs
@@ -1,0 +1,853 @@
+//! Criterion-adjacent coverage tracking for legal benchmark runs.
+//!
+//! This module tracks what the agent discovered, read, extracted, drafted, and
+//! validated without giving the model hidden rubric criteria in integrity mode.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use serde_json::Value;
+
+use crate::{
+    AgentVisibleChecklist, ArtifactManifest, BenchmarkTaskSpec, CoverageMode, CoverageSnapshot,
+    CriterionCoverageFailure, CriterionFailureClass, CriterionResult, CriterionVerdict,
+    DeliverableSectionCoverage, DerivedChecklistItem, DocumentCoverageEntry, EvidenceCoverageEntry,
+    FactCoverageEntry, LegalBenchmarkPathRoot, Metadata, RunConfig, SelfCheckCoverageEntry,
+    SourceArtifact, ToolCallRecord, TranscriptEvent, ValidationCoverageEntry, stable_json_digest,
+};
+
+pub const LEGAL_BENCHMARK_COVERAGE_SCHEMA_VERSION: u16 = 1;
+
+/// Returns the configured coverage mode. Integrity mode is the default.
+#[must_use]
+pub fn coverage_mode_from_metadata(metadata: &Metadata) -> CoverageMode {
+    metadata
+        .get("coverage_mode")
+        .and_then(Value::as_str)
+        .map(|mode| match mode {
+            "hill_climb" | "training" => CoverageMode::HillClimb,
+            _ => CoverageMode::Integrity,
+        })
+        .unwrap_or(CoverageMode::Integrity)
+}
+
+/// Returns the configured run coverage mode.
+#[must_use]
+pub fn coverage_mode_from_run_config(run_config: &RunConfig) -> CoverageMode {
+    coverage_mode_from_metadata(&run_config.metadata)
+}
+
+/// Builds the model-visible checklist under the configured policy.
+#[must_use]
+pub fn agent_visible_checklist(run_config: &RunConfig) -> AgentVisibleChecklist {
+    let mode = coverage_mode_from_run_config(run_config);
+    let items = match mode {
+        CoverageMode::Integrity => Vec::new(),
+        CoverageMode::HillClimb => derived_checklist_items(&run_config.metadata)
+            .into_iter()
+            .filter(|item| item.agent_visible)
+            .collect(),
+    };
+    AgentVisibleChecklist {
+        mode,
+        items,
+        hidden_criteria_visible: false,
+    }
+}
+
+/// Builds a coverage snapshot from run-time tool and transcript state.
+pub fn build_coverage_snapshot(
+    task_spec: &BenchmarkTaskSpec,
+    run_config: &RunConfig,
+    tool_calls: &[ToolCallRecord],
+    transcript: &[TranscriptEvent],
+    output_manifest: &ArtifactManifest,
+) -> Result<CoverageSnapshot, serde_json::Error> {
+    let checklist = agent_visible_checklist(run_config);
+    let mut documents = seed_document_entries(&task_spec.source_artifacts);
+    let mut facts = Vec::new();
+    let mut evidence_refs = Vec::new();
+    let mut deliverable_sections =
+        output_deliverable_sections(task_spec, output_manifest.artifacts.as_slice());
+
+    for call in tool_calls {
+        apply_tool_call_coverage(
+            task_spec,
+            call,
+            &mut documents,
+            &mut facts,
+            &mut evidence_refs,
+            &mut deliverable_sections,
+        )?;
+    }
+
+    let validations = build_deliverable_validations(task_spec, output_manifest);
+    let self_checks = transcript
+        .iter()
+        .filter_map(self_check_from_transcript_event)
+        .collect::<Vec<_>>();
+
+    Ok(CoverageSnapshot {
+        schema_version: LEGAL_BENCHMARK_COVERAGE_SCHEMA_VERSION,
+        mode: checklist.mode,
+        hidden_criteria_visible: model_visible_text_contains_hidden_criteria(task_spec, transcript),
+        derived_checklist_items: checklist.items,
+        documents: documents.into_values().collect(),
+        facts,
+        evidence_refs,
+        deliverable_sections,
+        validations,
+        self_checks,
+    })
+}
+
+/// Builds a conservative coverage snapshot for imported or historical runs that
+/// predate run-time coverage capture.
+#[must_use]
+pub fn fallback_coverage_snapshot(
+    task_spec: &BenchmarkTaskSpec,
+    output_manifest: &ArtifactManifest,
+) -> CoverageSnapshot {
+    CoverageSnapshot {
+        schema_version: LEGAL_BENCHMARK_COVERAGE_SCHEMA_VERSION,
+        mode: CoverageMode::Integrity,
+        hidden_criteria_visible: false,
+        derived_checklist_items: Vec::new(),
+        documents: seed_document_entries(&task_spec.source_artifacts)
+            .into_values()
+            .collect(),
+        facts: Vec::new(),
+        evidence_refs: Vec::new(),
+        deliverable_sections: output_deliverable_sections(
+            task_spec,
+            output_manifest.artifacts.as_slice(),
+        ),
+        validations: build_deliverable_validations(task_spec, output_manifest),
+        self_checks: Vec::new(),
+    }
+}
+
+/// Computes document read coverage from a snapshot.
+#[must_use]
+pub fn document_coverage_bps_from_snapshot(
+    task_spec: &BenchmarkTaskSpec,
+    snapshot: &CoverageSnapshot,
+) -> u32 {
+    if task_spec.source_artifacts.is_empty() {
+        return 10_000;
+    }
+    let read = snapshot
+        .documents
+        .iter()
+        .filter(|entry| entry.read)
+        .filter(|entry| {
+            task_spec.source_artifacts.iter().any(|artifact| {
+                artifact.artifact_id == entry.artifact_id
+                    || artifact.relative_path == entry.relative_path
+            })
+        })
+        .count();
+    u32::try_from((read * 10_000) / task_spec.source_artifacts.len())
+        .unwrap_or(0)
+        .min(10_000)
+}
+
+/// Compares missed criteria against coverage state after judging.
+#[must_use]
+pub fn classify_criterion_failures(
+    task_spec: &BenchmarkTaskSpec,
+    criterion_results: &[CriterionResult],
+    coverage: &CoverageSnapshot,
+) -> Vec<CriterionCoverageFailure> {
+    criterion_results
+        .iter()
+        .filter(|result| result.verdict != CriterionVerdict::Pass)
+        .filter_map(|result| {
+            let criterion = task_spec
+                .criteria
+                .iter()
+                .find(|criterion| criterion.criterion_id == result.criterion_id)?;
+            let read_sources = read_source_refs(coverage);
+            let missing_source_artifact_ids = criterion
+                .source_artifact_ids
+                .iter()
+                .filter(|source| !read_sources.contains(source.as_str()))
+                .cloned()
+                .collect::<Vec<_>>();
+            let drafted_deliverables = drafted_deliverable_ids(coverage);
+            let missing_deliverable_ids = criterion
+                .deliverable_ids
+                .iter()
+                .filter(|deliverable| !drafted_deliverables.contains(deliverable.as_str()))
+                .cloned()
+                .collect::<Vec<_>>();
+            let expected_source_refs =
+                expected_source_refs(task_spec, criterion.source_artifact_ids.as_slice());
+            let evidence_refs = criterion_evidence_refs(expected_source_refs.as_slice(), coverage);
+            let validation_failed = coverage.validations.iter().any(|validation| {
+                !validation.passed
+                    && criterion
+                        .deliverable_ids
+                        .iter()
+                        .any(|deliverable| validation.target_ref == *deliverable)
+            });
+            let failure_class = if !missing_source_artifact_ids.is_empty() {
+                CriterionFailureClass::CoverageGap
+            } else if !criterion.source_artifact_ids.is_empty() && evidence_refs.is_empty() {
+                CriterionFailureClass::ExtractionGap
+            } else if !missing_deliverable_ids.is_empty() || validation_failed {
+                CriterionFailureClass::DraftingGap
+            } else {
+                CriterionFailureClass::ReasoningGap
+            };
+            Some(CriterionCoverageFailure {
+                criterion_id: result.criterion_id.clone(),
+                failure_class,
+                missing_source_artifact_ids,
+                missing_deliverable_ids,
+                evidence_refs,
+                diagnostic: failure_diagnostic(failure_class),
+            })
+        })
+        .collect()
+}
+
+/// Returns true when model-visible transcript text contains raw hidden criteria.
+#[must_use]
+pub fn model_visible_text_contains_hidden_criteria(
+    task_spec: &BenchmarkTaskSpec,
+    transcript: &[TranscriptEvent],
+) -> bool {
+    let criteria = task_spec
+        .criteria
+        .iter()
+        .map(|criterion| criterion.description.trim())
+        .filter(|description| !description.is_empty())
+        .collect::<Vec<_>>();
+    if criteria.is_empty() {
+        return false;
+    }
+    transcript.iter().any(|event| {
+        if matches!(event.event_kind, crate::TranscriptEventKind::Judge) {
+            return false;
+        }
+        let mut visible = String::new();
+        if let Some(content) = &event.content {
+            visible.push_str(content);
+        }
+        if let Some(payload) = &event.payload {
+            visible.push_str(&payload.to_string());
+        }
+        criteria.iter().any(|criterion| visible.contains(criterion))
+    })
+}
+
+fn derived_checklist_items(metadata: &Metadata) -> Vec<DerivedChecklistItem> {
+    metadata
+        .get("derived_checklist_items")
+        .and_then(Value::as_array)
+        .map(|items| {
+            items
+                .iter()
+                .enumerate()
+                .filter_map(|(index, item)| derived_checklist_item(index, item))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn derived_checklist_item(index: usize, value: &Value) -> Option<DerivedChecklistItem> {
+    if let Some(prompt) = value.as_str() {
+        return Some(DerivedChecklistItem {
+            item_id: format!("derived.checklist.{index}"),
+            prompt: prompt.to_owned(),
+            source: String::from("run_config.metadata"),
+            agent_visible: true,
+        });
+    }
+    let object = value.as_object()?;
+    let prompt = object.get("prompt").and_then(Value::as_str)?.to_owned();
+    Some(DerivedChecklistItem {
+        item_id: object
+            .get("item_id")
+            .and_then(Value::as_str)
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("derived.checklist.{index}")),
+        prompt,
+        source: object
+            .get("source")
+            .and_then(Value::as_str)
+            .unwrap_or("run_config.metadata")
+            .to_owned(),
+        agent_visible: object
+            .get("agent_visible")
+            .and_then(Value::as_bool)
+            .unwrap_or(true),
+    })
+}
+
+fn seed_document_entries(
+    source_artifacts: &[SourceArtifact],
+) -> BTreeMap<String, DocumentCoverageEntry> {
+    source_artifacts
+        .iter()
+        .map(|artifact| {
+            (
+                artifact.relative_path.clone(),
+                DocumentCoverageEntry {
+                    artifact_id: artifact.artifact_id.clone(),
+                    relative_path: artifact.relative_path.clone(),
+                    discovered: false,
+                    read: false,
+                    used_extracted_text: false,
+                },
+            )
+        })
+        .collect()
+}
+
+fn apply_tool_call_coverage(
+    task_spec: &BenchmarkTaskSpec,
+    call: &ToolCallRecord,
+    documents: &mut BTreeMap<String, DocumentCoverageEntry>,
+    facts: &mut Vec<FactCoverageEntry>,
+    evidence_refs: &mut Vec<EvidenceCoverageEntry>,
+    deliverable_sections: &mut Vec<DeliverableSectionCoverage>,
+) -> Result<(), serde_json::Error> {
+    match call.tool_name.as_str() {
+        "glob" => apply_glob_coverage(call, documents),
+        "grep" => apply_grep_coverage(call, documents, facts, evidence_refs)?,
+        "read" => apply_read_coverage(call, documents, facts)?,
+        "write" | "edit" => apply_write_coverage(task_spec, call, deliverable_sections),
+        _ => {}
+    }
+    Ok(())
+}
+
+fn apply_glob_coverage(
+    call: &ToolCallRecord,
+    documents: &mut BTreeMap<String, DocumentCoverageEntry>,
+) {
+    if !input_root_is_documents(call) {
+        return;
+    }
+    let Some(matches) = output_payload(call, "glob")
+        .and_then(|glob| glob.get("matches"))
+        .and_then(Value::as_array)
+    else {
+        return;
+    };
+    for relative_path in matches.iter().filter_map(Value::as_str) {
+        document_entry(documents, relative_path).discovered = true;
+    }
+}
+
+fn apply_read_coverage(
+    call: &ToolCallRecord,
+    documents: &mut BTreeMap<String, DocumentCoverageEntry>,
+    facts: &mut Vec<FactCoverageEntry>,
+) -> Result<(), serde_json::Error> {
+    if !input_root_is_documents(call) {
+        return Ok(());
+    }
+    let Some(relative_path) = input_payload(call)
+        .and_then(|input| input.get("relative_path"))
+        .and_then(Value::as_str)
+    else {
+        return Ok(());
+    };
+    let entry = document_entry(documents, relative_path);
+    entry.discovered = true;
+    entry.read = true;
+    entry.used_extracted_text = output_payload(call, "read")
+        .and_then(|read| read.get("source"))
+        .and_then(Value::as_str)
+        .is_some_and(|source| source == "extracted_text");
+    if let Some(content) = output_payload(call, "read")
+        .and_then(|read| read.get("content"))
+        .and_then(Value::as_str)
+    {
+        facts.push(FactCoverageEntry {
+            fact_id: format!("fact.{}.{}", stable_path_id(relative_path), facts.len()),
+            source_ref: relative_path.to_owned(),
+            text_hash: stable_json_digest("psionic.legal_benchmark.coverage.fact.v1", &content)?,
+            method: String::from("read"),
+        });
+    }
+    Ok(())
+}
+
+fn apply_grep_coverage(
+    call: &ToolCallRecord,
+    documents: &mut BTreeMap<String, DocumentCoverageEntry>,
+    facts: &mut Vec<FactCoverageEntry>,
+    evidence_refs: &mut Vec<EvidenceCoverageEntry>,
+) -> Result<(), serde_json::Error> {
+    if !input_root_is_documents(call) {
+        return Ok(());
+    }
+    let Some(matches) = output_payload(call, "grep")
+        .and_then(|grep| grep.get("matches"))
+        .and_then(Value::as_array)
+    else {
+        return Ok(());
+    };
+    for matched in matches {
+        let Some(relative_path) = matched.get("relative_path").and_then(Value::as_str) else {
+            continue;
+        };
+        document_entry(documents, relative_path).discovered = true;
+        let line_number = matched.get("line_number").and_then(Value::as_u64);
+        let line = matched
+            .get("line")
+            .and_then(Value::as_str)
+            .unwrap_or_default();
+        let span_hash = stable_json_digest("psionic.legal_benchmark.coverage.evidence.v1", &line)?;
+        let evidence_id = format!(
+            "evidence.{}.{}",
+            stable_path_id(relative_path),
+            line_number.unwrap_or(0)
+        );
+        evidence_refs.push(EvidenceCoverageEntry {
+            evidence_id: evidence_id.clone(),
+            source_ref: relative_path.to_owned(),
+            locator: line_number.map(|line| format!("line:{line}")),
+            span_hash: span_hash.clone(),
+        });
+        facts.push(FactCoverageEntry {
+            fact_id: format!("fact.{}.{}", stable_path_id(relative_path), facts.len()),
+            source_ref: relative_path.to_owned(),
+            text_hash: span_hash,
+            method: String::from("grep"),
+        });
+    }
+    Ok(())
+}
+
+fn apply_write_coverage(
+    task_spec: &BenchmarkTaskSpec,
+    call: &ToolCallRecord,
+    deliverable_sections: &mut Vec<DeliverableSectionCoverage>,
+) {
+    let root = input_root(call);
+    if !matches!(
+        root,
+        Some(LegalBenchmarkPathRoot::Output | LegalBenchmarkPathRoot::Workspace)
+    ) {
+        return;
+    }
+    let Some(relative_path) = input_payload(call)
+        .and_then(|input| input.get("relative_path"))
+        .and_then(Value::as_str)
+    else {
+        return;
+    };
+    let deliverable_id = deliverable_id_for_path(task_spec, relative_path)
+        .unwrap_or_else(|| format!("unmatched.{}", stable_path_id(relative_path)));
+    deliverable_sections.push(DeliverableSectionCoverage {
+        deliverable_id,
+        relative_path: relative_path.to_owned(),
+        section_id: format!("tool.{}.{}", call.tool_name, stable_path_id(relative_path)),
+        drafted: call.error_kind.is_none(),
+    });
+}
+
+pub(crate) fn build_deliverable_validations(
+    task_spec: &BenchmarkTaskSpec,
+    output_manifest: &ArtifactManifest,
+) -> Vec<crate::ValidationCoverageEntry> {
+    task_spec
+        .deliverables
+        .iter()
+        .map(|deliverable| {
+            let passed = output_manifest
+                .artifacts
+                .iter()
+                .any(|artifact| artifact.relative_path == deliverable.required_path);
+            ValidationCoverageEntry {
+                validation_id: format!("validation.deliverable.{}", deliverable.deliverable_id),
+                target_ref: deliverable.deliverable_id.clone(),
+                passed,
+                detail: if passed {
+                    format!("deliverable {} exists", deliverable.required_path)
+                } else {
+                    format!("deliverable {} missing", deliverable.required_path)
+                },
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn self_check_from_transcript_event(
+    event: &TranscriptEvent,
+) -> Option<SelfCheckCoverageEntry> {
+    let content = event.content.as_ref()?;
+    let lowered = content.to_ascii_lowercase();
+    if !(lowered.contains("self-check") || lowered.contains("self check")) {
+        return None;
+    }
+    Some(SelfCheckCoverageEntry {
+        self_check_id: format!("self_check.{}", event.event_index),
+        area: String::from("agent_declared"),
+        outcome: content.chars().take(240).collect(),
+    })
+}
+
+fn output_deliverable_sections(
+    task_spec: &BenchmarkTaskSpec,
+    artifacts: &[SourceArtifact],
+) -> Vec<crate::DeliverableSectionCoverage> {
+    artifacts
+        .iter()
+        .filter_map(|artifact| {
+            deliverable_id_for_path(task_spec, &artifact.relative_path).map(|deliverable_id| {
+                DeliverableSectionCoverage {
+                    deliverable_id,
+                    relative_path: artifact.relative_path.clone(),
+                    section_id: format!("output_manifest.{}", artifact.artifact_id),
+                    drafted: true,
+                }
+            })
+        })
+        .collect()
+}
+
+fn deliverable_id_for_path(task_spec: &BenchmarkTaskSpec, relative_path: &str) -> Option<String> {
+    task_spec
+        .deliverables
+        .iter()
+        .find(|deliverable| deliverable.required_path == relative_path)
+        .map(|deliverable| deliverable.deliverable_id.clone())
+}
+
+fn document_entry<'a>(
+    documents: &'a mut BTreeMap<String, DocumentCoverageEntry>,
+    relative_path: &str,
+) -> &'a mut DocumentCoverageEntry {
+    documents
+        .entry(relative_path.to_owned())
+        .or_insert_with(|| DocumentCoverageEntry {
+            artifact_id: relative_path.to_owned(),
+            relative_path: relative_path.to_owned(),
+            discovered: false,
+            read: false,
+            used_extracted_text: false,
+        })
+}
+
+fn input_root_is_documents(call: &ToolCallRecord) -> bool {
+    matches!(input_root(call), Some(LegalBenchmarkPathRoot::Documents))
+}
+
+fn input_root(call: &ToolCallRecord) -> Option<LegalBenchmarkPathRoot> {
+    match input_payload(call)?.get("root").and_then(Value::as_str)? {
+        "documents" => Some(LegalBenchmarkPathRoot::Documents),
+        "workspace" => Some(LegalBenchmarkPathRoot::Workspace),
+        "output" => Some(LegalBenchmarkPathRoot::Output),
+        _ => None,
+    }
+}
+
+fn input_payload(call: &ToolCallRecord) -> Option<&Value> {
+    call.input.get("input").or(Some(&call.input))
+}
+
+fn output_payload<'a>(call: &'a ToolCallRecord, expected_tool: &str) -> Option<&'a Value> {
+    let output = call.output.as_ref()?;
+    if output.get("tool").and_then(Value::as_str)? != expected_tool {
+        return None;
+    }
+    output.get("output")
+}
+
+fn read_source_refs(coverage: &CoverageSnapshot) -> BTreeSet<&str> {
+    coverage
+        .documents
+        .iter()
+        .filter(|entry| entry.read)
+        .flat_map(|entry| [entry.artifact_id.as_str(), entry.relative_path.as_str()])
+        .collect()
+}
+
+fn drafted_deliverable_ids(coverage: &CoverageSnapshot) -> BTreeSet<&str> {
+    coverage
+        .deliverable_sections
+        .iter()
+        .filter(|section| section.drafted)
+        .map(|section| section.deliverable_id.as_str())
+        .collect()
+}
+
+fn criterion_evidence_refs(
+    expected_source_refs: &[String],
+    coverage: &CoverageSnapshot,
+) -> Vec<String> {
+    if expected_source_refs.is_empty() {
+        return coverage
+            .evidence_refs
+            .iter()
+            .map(|evidence| evidence.evidence_id.clone())
+            .collect();
+    }
+    coverage
+        .evidence_refs
+        .iter()
+        .filter(|evidence| {
+            expected_source_refs
+                .iter()
+                .any(|source| source == &evidence.source_ref)
+        })
+        .map(|evidence| evidence.evidence_id.clone())
+        .collect()
+}
+
+fn expected_source_refs(
+    task_spec: &BenchmarkTaskSpec,
+    source_artifact_ids: &[String],
+) -> Vec<String> {
+    let mut refs = source_artifact_ids.to_vec();
+    for source_id in source_artifact_ids {
+        if let Some(artifact) = task_spec
+            .source_artifacts
+            .iter()
+            .find(|artifact| artifact.artifact_id == *source_id)
+        {
+            refs.push(artifact.relative_path.clone());
+        }
+    }
+    refs
+}
+
+fn failure_diagnostic(failure_class: CriterionFailureClass) -> String {
+    match failure_class {
+        CriterionFailureClass::CoverageGap => {
+            String::from("missed criterion aligns to unread required source artifacts")
+        }
+        CriterionFailureClass::ExtractionGap => {
+            String::from("source artifacts were read but no matching evidence was captured")
+        }
+        CriterionFailureClass::DraftingGap => {
+            String::from("evidence was available but required deliverable drafting was incomplete")
+        }
+        CriterionFailureClass::ReasoningGap => {
+            String::from("coverage was present, so remaining miss is classified as reasoning")
+        }
+        CriterionFailureClass::Passed => String::from("criterion passed"),
+    }
+}
+
+fn stable_path_id(path: &str) -> String {
+    path.chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || matches!(ch, '-' | '_') {
+                ch
+            } else {
+                '.'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        ArtifactKind, ArtifactManifestRole, CriterionKind, DeliverableKind, DeliverableSpec,
+        JudgeMode, JudgePolicy, RunMetrics, RunRecord, RunTerminalState, SourceArtifact,
+        ToolPolicy, TranscriptEvent, TranscriptEventKind,
+    };
+    use serde_json::json;
+
+    fn source_artifact() -> SourceArtifact {
+        SourceArtifact {
+            artifact_id: String::from("source.contract"),
+            artifact_kind: ArtifactKind::SourceDocument,
+            relative_path: String::from("contract.txt"),
+            original_filename: String::from("contract.txt"),
+            media_type: String::from("text/plain"),
+            byte_size: 100,
+            sha256: String::from("hash"),
+            data_classification: crate::DataClassification::BenchmarkConfidential,
+            provenance: None,
+        }
+    }
+
+    fn task_spec() -> BenchmarkTaskSpec {
+        BenchmarkTaskSpec {
+            schema_version: crate::LEGAL_BENCHMARK_SCHEMA_VERSION,
+            task_id: String::from("legal.coverage.test"),
+            task_version: String::from("v1"),
+            domain: String::from("legal"),
+            practice_area: String::from("contracts"),
+            workflow: String::from("review"),
+            title: String::from("Coverage test"),
+            instructions: String::from("Review the contract."),
+            work_type: String::from("review"),
+            tags: Vec::new(),
+            source_artifacts: vec![source_artifact()],
+            deliverables: vec![DeliverableSpec {
+                deliverable_id: String::from("memo"),
+                deliverable_kind: DeliverableKind::Markdown,
+                required_path: String::from("memo.md"),
+                description: String::from("Memo"),
+                required: true,
+            }],
+            criteria: vec![crate::CriterionSpec {
+                criterion_id: String::from("criterion.source"),
+                criterion_kind: CriterionKind::FactualAccuracy,
+                description: String::from("Hidden source criterion"),
+                weight_bps: Some(10_000),
+                deliverable_ids: vec![String::from("memo")],
+                source_artifact_ids: vec![String::from("source.contract")],
+            }],
+            judge_policy: JudgePolicy {
+                mode: JudgeMode::Deterministic,
+                provider: String::from("mock"),
+                model: String::from("judge"),
+                prompt_template_id: String::from("judge"),
+                prompt_template_hash: String::from("hash"),
+                all_pass_required: true,
+                sample_count: 1,
+            },
+            tool_policy: ToolPolicy {
+                allowed_tools: vec![String::from("read"), String::from("write")],
+                network_allowed: false,
+                source_artifacts_read_only: true,
+                max_turns: 4,
+                max_wall_time_seconds: 60,
+            },
+            source_compatibility: None,
+            metadata: Metadata::new(),
+        }
+    }
+
+    fn run_config(mode: &str) -> RunConfig {
+        let mut metadata = Metadata::new();
+        metadata.insert(
+            String::from("coverage_mode"),
+            Value::String(mode.to_owned()),
+        );
+        metadata.insert(
+            String::from("derived_checklist_items"),
+            json!([{"item_id":"derived.inventory","prompt":"Inventory every source document before drafting.","source":"operator","agent_visible":true}]),
+        );
+        RunConfig {
+            schema_version: crate::LEGAL_BENCHMARK_SCHEMA_VERSION,
+            run_config_id: String::from("config"),
+            provider: String::from("mock"),
+            model: String::from("mock"),
+            agent_protocol_version: String::from("v1"),
+            tool_policy: task_spec().tool_policy,
+            judge_policy: task_spec().judge_policy,
+            random_seed: None,
+            metadata,
+        }
+    }
+
+    #[test]
+    fn integrity_mode_hides_derived_checklist() {
+        let checklist = agent_visible_checklist(&run_config("integrity"));
+        assert_eq!(checklist.mode, CoverageMode::Integrity);
+        assert!(checklist.items.is_empty());
+        assert!(!checklist.hidden_criteria_visible);
+    }
+
+    #[test]
+    fn hill_climb_mode_allows_policy_approved_checklist() {
+        let checklist = agent_visible_checklist(&run_config("hill_climb"));
+        assert_eq!(checklist.mode, CoverageMode::HillClimb);
+        assert_eq!(checklist.items.len(), 1);
+        assert_eq!(checklist.items[0].item_id, "derived.inventory");
+    }
+
+    #[test]
+    fn coverage_snapshot_classifies_coverage_gap_without_hidden_hint() {
+        let task = task_spec();
+        let run_config = run_config("integrity");
+        let output_manifest = ArtifactManifest {
+            schema_version: crate::LEGAL_BENCHMARK_SCHEMA_VERSION,
+            manifest_id: String::from("output"),
+            task_id: task.task_id.clone(),
+            task_version: task.task_version.clone(),
+            manifest_role: ArtifactManifestRole::Output,
+            artifacts: Vec::new(),
+            metadata: Metadata::new(),
+        };
+        let transcript = vec![TranscriptEvent {
+            event_index: 0,
+            event_kind: TranscriptEventKind::User,
+            role: Some(String::from("user")),
+            content: Some(String::from("Review the contract.")),
+            payload: None,
+            timestamp_ms: 0,
+        }];
+        let snapshot =
+            build_coverage_snapshot(&task, &run_config, &[], &transcript, &output_manifest)
+                .expect("coverage");
+        assert!(!snapshot.hidden_criteria_visible);
+        let failures = classify_criterion_failures(
+            &task,
+            &[CriterionResult {
+                criterion_id: String::from("criterion.source"),
+                passed: false,
+                verdict: CriterionVerdict::Fail,
+                reasoning: String::from("missed"),
+                evidence_refs: Vec::new(),
+                judge_model: String::from("mock"),
+                judge_prompt_hash: String::from("hash"),
+                raw_response_hash: String::from("raw"),
+                confidence_bps: None,
+                judge_latency_ms: None,
+                judge_cost_micro_usd: None,
+            }],
+            &snapshot,
+        );
+        assert_eq!(
+            failures[0].failure_class,
+            CriterionFailureClass::CoverageGap
+        );
+    }
+
+    #[test]
+    fn model_visible_detector_finds_hidden_criteria_leak() {
+        let task = task_spec();
+        let transcript = vec![TranscriptEvent {
+            event_index: 0,
+            event_kind: TranscriptEventKind::User,
+            role: Some(String::from("user")),
+            content: Some(String::from("Hidden source criterion")),
+            payload: None,
+            timestamp_ms: 0,
+        }];
+        assert!(model_visible_text_contains_hidden_criteria(
+            &task,
+            &transcript
+        ));
+    }
+
+    #[allow(dead_code)]
+    fn _run_record_compiles_with_coverage(snapshot: CoverageSnapshot) -> RunRecord {
+        RunRecord {
+            schema_version: crate::LEGAL_BENCHMARK_SCHEMA_VERSION,
+            run_id: String::from("run"),
+            task_id: String::from("task"),
+            task_version: String::from("v1"),
+            input_artifact_manifest_hash: String::from("input"),
+            run_config_hash: String::from("config"),
+            output_artifact_manifest_hash: String::from("output"),
+            terminal_state: RunTerminalState::Submitted,
+            transcript: Vec::new(),
+            tool_calls: Vec::new(),
+            metrics: RunMetrics {
+                model_turns: 0,
+                tool_call_count: 0,
+                input_tokens: 0,
+                output_tokens: 0,
+                wall_time_ms: 0,
+                estimated_cost_micro_usd: 0,
+            },
+            extraction_receipt_refs: Vec::new(),
+            coverage_snapshot: Some(snapshot),
+            metadata: Metadata::new(),
+        }
+    }
+}

--- a/crates/psionic-eval/src/legal_benchmark_evaluator.rs
+++ b/crates/psionic-eval/src/legal_benchmark_evaluator.rs
@@ -11,8 +11,9 @@ use thiserror::Error;
 use crate::{
     ArtifactManifest, ArtifactManifestError, BenchmarkTaskSpec, CriterionResult, CriterionSpec,
     CriterionVerdict, DeliverableKind, DeliverableSpec, JudgePolicy, Metadata, RunRecord,
-    ScoreReport, SourceArtifact, artifact_from_file, artifact_manifest_digest, run_record_digest,
-    score_report_digest, stable_json_digest,
+    ScoreReport, SourceArtifact, artifact_from_file, artifact_manifest_digest,
+    classify_criterion_failures, document_coverage_bps_from_snapshot, fallback_coverage_snapshot,
+    run_record_digest, score_report_digest, stable_json_digest,
 };
 
 pub const LEGAL_BENCHMARK_EVALUATOR_SCHEMA_VERSION: u16 = 1;
@@ -202,6 +203,15 @@ where
     metrics.wall_time_ms = metrics.wall_time_ms.saturating_add(total_judge_latency);
     let output_manifest_hash = artifact_manifest_digest(&input.output_artifact_manifest)?;
     let run_record_hash = run_record_digest(&input.run_record)?;
+    let coverage_snapshot = input
+        .run_record
+        .coverage_snapshot
+        .clone()
+        .unwrap_or_else(|| {
+            fallback_coverage_snapshot(&input.task_spec, &input.output_artifact_manifest)
+        });
+    let failure_comparisons =
+        classify_criterion_failures(&input.task_spec, &criterion_results, &coverage_snapshot);
     let mut metadata = Metadata::new();
     metadata.insert(
         String::from("precheck_count"),
@@ -226,9 +236,14 @@ where
         criterion_pass_rate_bps,
         criterion_results,
         metrics,
-        document_coverage_bps: document_coverage_bps(input),
+        document_coverage_bps: document_coverage_bps_from_snapshot(
+            &input.task_spec,
+            &coverage_snapshot,
+        ),
         failure_diagnostics,
         extraction_receipt_refs: input.run_record.extraction_receipt_refs.clone(),
+        coverage_snapshot: Some(coverage_snapshot),
+        failure_comparisons,
         metadata,
     };
     let score_report_hash = score_report_digest(&score_report)?;
@@ -449,21 +464,6 @@ fn deliverable_type_matches(deliverable: &DeliverableSpec, path: &Path) -> bool 
     }
 }
 
-fn document_coverage_bps(input: &LegalBenchmarkEvaluationInput) -> u32 {
-    if input.task_spec.source_artifacts.is_empty() {
-        return 10_000;
-    }
-    let referenced = input
-        .task_spec
-        .criteria
-        .iter()
-        .flat_map(|criterion| criterion.source_artifact_ids.iter())
-        .collect::<BTreeSet<_>>();
-    u32::try_from((referenced.len() * 10_000) / input.task_spec.source_artifacts.len())
-        .unwrap_or(0)
-        .min(10_000)
-}
-
 fn default_judge_prompt_template(policy: &JudgePolicy) -> String {
     format!(
         "Judge each legal benchmark criterion using all-pass semantics. template={} mode={:?} samples={}",
@@ -576,6 +576,7 @@ mod tests {
                 estimated_cost_micro_usd: 12,
             },
             extraction_receipt_refs: vec![String::from("extract.1")],
+            coverage_snapshot: None,
             metadata: Metadata::new(),
         }
     }

--- a/crates/psionic-eval/src/legal_benchmark_reports.rs
+++ b/crates/psionic-eval/src/legal_benchmark_reports.rs
@@ -6,8 +6,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    ArtifactManifest, ComparisonReport, CriterionResult, CriterionVerdict, Metadata, RunRecord,
-    ScoreReport, comparison_report_digest, score_report_digest, stable_json_digest,
+    ArtifactManifest, ComparisonReport, CriterionCoverageFailure, CriterionResult,
+    CriterionVerdict, Metadata, RunRecord, ScoreReport, comparison_report_digest,
+    score_report_digest, stable_json_digest,
 };
 
 pub const LEGAL_BENCHMARK_REPORT_SCHEMA_VERSION: u16 = 1;
@@ -77,6 +78,8 @@ pub struct LegalBenchmarkAutopilotReportExport {
     pub by_task: Vec<LegalBenchmarkTaskSummary>,
     pub by_model_config: Vec<LegalBenchmarkModelConfigSummary>,
     pub failure_clusters: Vec<LegalBenchmarkFailureCluster>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub coverage_failure_comparisons: Vec<CriterionCoverageFailure>,
     pub score_report_hashes: Vec<String>,
     #[serde(default, skip_serializing_if = "Metadata::is_empty")]
     pub metadata: Metadata,
@@ -96,6 +99,11 @@ pub fn generate_legal_benchmark_static_report(
     let by_task = summarize_by_task(&input.score_reports)?;
     let by_model_config = summarize_by_model_config(&input.score_reports, &input.run_records);
     let failure_clusters = failure_clusters(&input.score_reports);
+    let coverage_failure_comparisons = input
+        .score_reports
+        .iter()
+        .flat_map(|report| report.failure_comparisons.iter().cloned())
+        .collect::<Vec<_>>();
     let score_report_hashes = input
         .score_reports
         .iter()
@@ -110,6 +118,7 @@ pub fn generate_legal_benchmark_static_report(
         by_task,
         by_model_config,
         failure_clusters,
+        coverage_failure_comparisons,
         score_report_hashes,
         metadata: Metadata::new(),
     };
@@ -385,9 +394,15 @@ fn render_markdown_report(
         } else {
             markdown.push_str("Missed criteria:\n\n");
             for criterion in missed {
+                let coverage_class = report
+                    .failure_comparisons
+                    .iter()
+                    .find(|comparison| comparison.criterion_id == criterion.criterion_id)
+                    .map(|comparison| format!("; coverage={:?}", comparison.failure_class))
+                    .unwrap_or_default();
                 markdown.push_str(&format!(
-                    "- {}: {:?}; {}\n",
-                    criterion.criterion_id, criterion.verdict, criterion.reasoning
+                    "- {}: {:?}{}; {}\n",
+                    criterion.criterion_id, criterion.verdict, coverage_class, criterion.reasoning
                 ));
             }
             markdown.push('\n');
@@ -485,7 +500,7 @@ fn now_ms() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{CriterionResult, RunMetrics};
+    use crate::{CriterionCoverageFailure, CriterionFailureClass, CriterionResult, RunMetrics};
 
     fn fixture_score_report() -> ScoreReport {
         serde_json::from_str(include_str!(
@@ -532,6 +547,14 @@ mod tests {
             judge_latency_ms: Some(2),
             judge_cost_micro_usd: Some(1),
         }];
+        score.failure_comparisons = vec![CriterionCoverageFailure {
+            criterion_id: String::from("criterion.reasoning"),
+            failure_class: CriterionFailureClass::CoverageGap,
+            missing_source_artifact_ids: vec![String::from("source.contract")],
+            missing_deliverable_ids: Vec::new(),
+            evidence_refs: Vec::new(),
+            diagnostic: String::from("missed source material"),
+        }];
         score.metrics = RunMetrics {
             model_turns: 1,
             tool_call_count: 0,
@@ -553,6 +576,11 @@ mod tests {
             report.autopilot_export.failure_clusters[0].failure_family,
             "judge_fail"
         );
+        assert_eq!(
+            report.autopilot_export.coverage_failure_comparisons.len(),
+            1
+        );
         assert!(report.markdown.contains("Missed criteria"));
+        assert!(report.markdown.contains("coverage=CoverageGap"));
     }
 }

--- a/crates/psionic-eval/src/lib.rs
+++ b/crates/psionic-eval/src/lib.rs
@@ -14,6 +14,7 @@ mod legal_benchmark;
 mod legal_benchmark_agent;
 #[cfg(test)]
 mod legal_benchmark_ci;
+mod legal_benchmark_coverage;
 mod legal_benchmark_evaluator;
 mod legal_benchmark_extraction;
 mod legal_benchmark_harvey;
@@ -24,6 +25,7 @@ mod legal_benchmark_tools;
 
 pub use legal_benchmark::*;
 pub use legal_benchmark_agent::*;
+pub use legal_benchmark_coverage::*;
 pub use legal_benchmark_evaluator::*;
 pub use legal_benchmark_extraction::*;
 pub use legal_benchmark_harvey::*;

--- a/docs/LEGAL_BENCHMARK_CI.md
+++ b/docs/LEGAL_BENCHMARK_CI.md
@@ -16,6 +16,7 @@ The check script runs:
 
 - Harvey corpus metadata fixture checks
 - minimal normalized task snapshot checks
+- coverage tracker integrity and hill-climb policy checks
 - sandbox traversal and symlink escape checks
 - mock report generation checks
 - mock sweep manifest checks

--- a/docs/LEGAL_BENCHMARK_COVERAGE.md
+++ b/docs/LEGAL_BENCHMARK_COVERAGE.md
@@ -1,0 +1,62 @@
+# Legal Benchmark Coverage Tracker
+
+> Status: implemented_early.
+
+The coverage tracker lives in
+`crates/psionic-eval/src/legal_benchmark_coverage.rs`. It records
+criterion-adjacent state during a run without exposing hidden Harvey
+`match_criteria` text to the model in integrity mode.
+
+## Modes
+
+- `integrity`: default mode. The runner does not render raw criteria or
+  derived checklist hints into model-visible task prompts.
+- `hill_climb`: training mode. The runner may render policy-approved
+  `derived_checklist_items` from `RunConfig.metadata`, but still does not
+  render hidden criteria text.
+
+The user prompt now includes task instructions and deliverables. Criteria are
+used only by the evaluator and post-judge failure classifier.
+
+## Snapshot Contents
+
+`CoverageSnapshot` records:
+
+- discovered and read source documents
+- whether extracted text was used
+- facts and evidence spans captured by read/grep-style tools
+- drafted deliverable sections
+- deliverable validations
+- agent self-check declarations
+- policy-approved derived checklist items
+- whether hidden criteria appeared in model-visible transcript text
+
+`RunRecord` persists the snapshot for replay. `ScoreReport` copies the snapshot
+and adds post-judge `failure_comparisons`.
+
+## Failure Classes
+
+After judging, missed criteria are compared to the snapshot and classified as:
+
+- `coverage_gap`: required source material was not read
+- `extraction_gap`: source material was read but no matching evidence was
+  captured
+- `drafting_gap`: evidence was available but the required output was missing or
+  failed validation
+- `reasoning_gap`: coverage and drafting were present, so the miss is likely
+  legal reasoning or application quality
+
+Reports export these comparisons for Autopilot4 failure clustering and
+improvement planning.
+
+## Validation
+
+Run:
+
+```bash
+cargo test -p psionic-eval --no-default-features --lib legal_benchmark
+```
+
+The coverage tests prove integrity mode hides derived hints, hill-climb mode
+allows approved checklist items, hidden criterion leaks are detectable, and a
+known miss is classified as a coverage gap.

--- a/docs/LEGAL_BENCHMARK_ENGINE.md
+++ b/docs/LEGAL_BENCHMARK_ENGINE.md
@@ -23,6 +23,7 @@ The `psionic-eval` legal benchmark module defines:
 - `TranscriptEvent`
 - `ToolCallRecord`
 - `RunMetrics`
+- `CoverageSnapshot`
 - `CriterionResult`
 - `ScoreReport`
 - `ComparisonReport`
@@ -180,6 +181,22 @@ and writes `config.json`, `transcript.jsonl`, `metrics.json`,
 `output_artifact_manifest.json`, `extraction_receipts.json`,
 `tool_receipts.json`, `run_record.json`, and `run_receipt.json`.
 
+Integrity mode is the default prompt policy. The runner does not render hidden
+criteria into model-visible messages; hill-climb runs may render only
+policy-approved derived checklist items from run config metadata.
+
+## Coverage Tracker
+
+Criterion-adjacent coverage tracking is documented in
+`docs/LEGAL_BENCHMARK_COVERAGE.md` and implemented in
+`crates/psionic-eval/src/legal_benchmark_coverage.rs`.
+
+Run records persist `CoverageSnapshot` values covering discovered/read
+documents, extracted facts, evidence refs, drafted deliverable sections,
+validations, self-checks, and the policy mode used. Score reports copy the
+snapshot and add post-judge failure comparisons that classify missed criteria
+as coverage, extraction, drafting, or reasoning gaps for Autopilot4 import.
+
 ## Evaluator And Judge Interface
 
 The criterion-scoped evaluator is documented in
@@ -190,7 +207,8 @@ It loads completed task/run/output-manifest artifacts, runs deterministic
 manifest and deliverable prechecks, extracts output text per criterion, calls a
 provider-neutral judge adapter, and emits `ScoreReport` values with all-pass
 status, criterion pass rate, judge provenance, confidence, latency, cost,
-document coverage, failure diagnostics, and extraction receipt refs.
+document coverage, failure diagnostics, extraction receipt refs, coverage
+snapshots, and missed-criterion failure classifications.
 
 ## Static Reports
 

--- a/docs/LEGAL_BENCHMARK_REPORTS.md
+++ b/docs/LEGAL_BENCHMARK_REPORTS.md
@@ -17,10 +17,12 @@ The generator produces:
 - per-model-config summaries
 - pairwise comparison reports
 - failure cluster exports
+- coverage failure comparisons
 
 Reports include all-pass state, missed criteria, judge reasoning summaries,
 artifact/run hashes, cost, latency, token usage, document coverage, extraction
-receipt refs, and failure diagnostics.
+receipt refs, coverage snapshots, coverage-vs-criterion failure classes, and
+failure diagnostics.
 
 ## Failure Clusters
 
@@ -34,6 +36,14 @@ Failure clusters group missed criteria by family:
 Each cluster records task ids, criterion ids, failure count, score delta,
 affected modules, diagnostics, and a repro command. Autopilot4 can import the
 JSON directly for dashboards, Work Orders, and issue generation.
+
+## Coverage Failure Comparisons
+
+Score reports may include `failure_comparisons` generated after judging. Each
+comparison classifies a missed criterion as `coverage_gap`, `extraction_gap`,
+`drafting_gap`, or `reasoning_gap`. The Autopilot export copies these rows so
+failure clusters can be imported without replaying hidden rubric text through
+model-visible prompts.
 
 ## Command
 

--- a/fixtures/legal_benchmark/evaluator_mock_score_report.json
+++ b/fixtures/legal_benchmark/evaluator_mock_score_report.json
@@ -34,6 +34,48 @@
   "document_coverage_bps": 10000,
   "failure_diagnostics": [],
   "extraction_receipt_refs": ["extract.1"],
+  "coverage_snapshot": {
+    "schema_version": 1,
+    "mode": "integrity",
+    "hidden_criteria_visible": false,
+    "derived_checklist_items": [],
+    "documents": [
+      {
+        "artifact_id": "source.memo",
+        "relative_path": "case.txt",
+        "discovered": true,
+        "read": true,
+        "used_extracted_text": true
+      }
+    ],
+    "facts": [
+      {
+        "fact_id": "fact.case.0",
+        "source_ref": "case.txt",
+        "text_hash": "eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",
+        "method": "read"
+      }
+    ],
+    "evidence_refs": [],
+    "deliverable_sections": [
+      {
+        "deliverable_id": "memo",
+        "relative_path": "memo.md",
+        "section_id": "output_manifest.artifact.output.0",
+        "drafted": true
+      }
+    ],
+    "validations": [
+      {
+        "validation_id": "validation.deliverable.memo",
+        "target_ref": "memo",
+        "passed": true,
+        "detail": "deliverable memo.md exists"
+      }
+    ],
+    "self_checks": []
+  },
+  "failure_comparisons": [],
   "metadata": {
     "precheck_count": 2,
     "judge_prompt_template_hash": "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"

--- a/scripts/check-legal-benchmark-ci.sh
+++ b/scripts/check-legal-benchmark-ci.sh
@@ -5,6 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
 cargo test -p psionic-eval --no-default-features --lib legal_benchmark_ci
+cargo test -p psionic-eval --no-default-features --lib legal_benchmark_coverage
 cargo test -p psionic-eval --no-default-features --lib legal_benchmark_reports
 cargo test -p psionic-eval --no-default-features --lib legal_benchmark_sweeps
 


### PR DESCRIPTION
Summary:
- Adds criterion-adjacent CoverageSnapshot schema, integrity/hill-climb modes, derived checklist policy controls, and post-judge failure classes.
- Wires the runner to persist coverage snapshots while removing hidden criterion text from model-visible task prompts in default integrity mode.
- Wires the evaluator and static reports to copy coverage state and export missed-criterion classifications for Autopilot4 import.
- Updates CI, docs, and the score-report fixture for coverage-aware reports.

Validation:
- scripts/check-legal-benchmark-ci.sh
- cargo test -p psionic-eval --no-default-features --lib
- cargo test -p psionic-eval --lib legal_benchmark_coverage
- git diff --cached --check

Closes #998