### PR TITLE
Add legal benchmark sweep matrix

### DIFF
--- a/crates/psionic-eval/src/legal_benchmark_sweeps.rs
+++ b/crates/psionic-eval/src/legal_benchmark_sweeps.rs
@@ -40,6 +40,68 @@ pub struct LegalBenchmarkSweepConfig {
     pub metadata: Metadata,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkSweepMatrixConfig {
+    pub schema_version: u16,
+    pub matrix_id: String,
+    pub scope: LegalBenchmarkSweepScope,
+    pub task_ids: Vec<String>,
+    pub providers: Vec<LegalBenchmarkSweepProviderAxis>,
+    pub reasoning_efforts: Vec<LegalBenchmarkSweepNamedAxis>,
+    pub context_budgets: Vec<LegalBenchmarkSweepContextBudgetAxis>,
+    pub extraction_policies: Vec<LegalBenchmarkSweepNamedAxis>,
+    pub tool_policies: Vec<LegalBenchmarkSweepNamedAxis>,
+    pub max_parallelism: u16,
+    pub budget: LegalBenchmarkSweepBudget,
+    #[serde(default, skip_serializing_if = "Metadata::is_empty")]
+    pub metadata: Metadata,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkSweepProviderAxis {
+    pub provider_id: String,
+    pub provider_family: String,
+    pub model: String,
+    pub route_id: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkSweepNamedAxis {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Metadata::is_empty")]
+    pub metadata: Metadata,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkSweepContextBudgetAxis {
+    pub id: String,
+    pub max_input_tokens: u64,
+    pub max_output_tokens: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkSweepMatrixRunConfig {
+    pub run_config_hash: String,
+    pub provider_id: String,
+    pub provider_family: String,
+    pub model: String,
+    pub route_id: String,
+    pub reasoning_effort_id: String,
+    pub context_budget_id: String,
+    pub max_input_tokens: u64,
+    pub max_output_tokens: u64,
+    pub extraction_policy_id: String,
+    pub tool_policy_id: String,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkSweepMatrixPlan {
+    pub schema_version: u16,
+    pub matrix_id: String,
+    pub sweep_config: LegalBenchmarkSweepConfig,
+    pub run_configs: Vec<LegalBenchmarkSweepMatrixRunConfig>,
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LegalBenchmarkSweepJobStatus {
@@ -72,6 +134,12 @@ pub struct LegalBenchmarkSweepJobRecord {
     pub wall_time_ms: u64,
     pub input_tokens: u64,
     pub output_tokens: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub all_pass: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub criterion_pass_rate_bps: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub document_coverage_bps: Option<u32>,
     pub failure_kind: Option<String>,
     pub failure_detail: Option<String>,
 }
@@ -105,6 +173,37 @@ pub struct LegalBenchmarkSweepManifest {
     pub metadata: Metadata,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkSweepMatrixConfigSummary {
+    pub run_config_hash: String,
+    pub total_jobs: u64,
+    pub succeeded_jobs: u64,
+    pub failed_jobs: u64,
+    pub all_pass_rate_bps: u32,
+    pub criterion_pass_rate_bps: u32,
+    pub document_coverage_bps: u32,
+    pub reliability_bps: u32,
+    pub total_cost_micro_usd: u64,
+    pub avg_wall_time_ms: u64,
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub pareto_front: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkSweepMatrixExport {
+    pub schema_version: u16,
+    pub matrix_id: String,
+    pub sweep_id: String,
+    pub generated_at_ms: u64,
+    pub manifest_hash: String,
+    pub config_hashes: Vec<String>,
+    pub summaries: Vec<LegalBenchmarkSweepMatrixConfigSummary>,
+    pub pareto_front_config_hashes: Vec<String>,
+    #[serde(default, skip_serializing_if = "Metadata::is_empty")]
+    pub metadata: Metadata,
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LegalBenchmarkSweepJobOutcome {
     pub status: LegalBenchmarkSweepJobStatus,
@@ -115,6 +214,9 @@ pub struct LegalBenchmarkSweepJobOutcome {
     pub wall_time_ms: u64,
     pub input_tokens: u64,
     pub output_tokens: u64,
+    pub all_pass: Option<bool>,
+    pub criterion_pass_rate_bps: Option<u32>,
+    pub document_coverage_bps: Option<u32>,
     pub failure_kind: Option<String>,
     pub failure_detail: Option<String>,
 }
@@ -149,10 +251,64 @@ impl LegalBenchmarkSweepExecutor for MockLegalBenchmarkSweepExecutor {
                 wall_time_ms: 1,
                 input_tokens: 1,
                 output_tokens: 1,
+                all_pass: Some(true),
+                criterion_pass_rate_bps: Some(10_000),
+                document_coverage_bps: Some(10_000),
                 failure_kind: None,
                 failure_detail: None,
             })
     }
+}
+
+pub fn expand_legal_benchmark_sweep_matrix(
+    matrix: &LegalBenchmarkSweepMatrixConfig,
+) -> Result<LegalBenchmarkSweepMatrixPlan, serde_json::Error> {
+    let mut run_configs = Vec::new();
+    for provider in &matrix.providers {
+        for reasoning in &matrix.reasoning_efforts {
+            for context in &matrix.context_budgets {
+                for extraction in &matrix.extraction_policies {
+                    for tool_policy in &matrix.tool_policies {
+                        let mut run_config = LegalBenchmarkSweepMatrixRunConfig {
+                            run_config_hash: String::new(),
+                            provider_id: provider.provider_id.clone(),
+                            provider_family: provider.provider_family.clone(),
+                            model: provider.model.clone(),
+                            route_id: provider.route_id.clone(),
+                            reasoning_effort_id: reasoning.id.clone(),
+                            context_budget_id: context.id.clone(),
+                            max_input_tokens: context.max_input_tokens,
+                            max_output_tokens: context.max_output_tokens,
+                            extraction_policy_id: extraction.id.clone(),
+                            tool_policy_id: tool_policy.id.clone(),
+                        };
+                        run_config.run_config_hash =
+                            legal_benchmark_sweep_matrix_run_config_hash(&run_config)?;
+                        run_configs.push(run_config);
+                    }
+                }
+            }
+        }
+    }
+    let sweep_config = LegalBenchmarkSweepConfig {
+        schema_version: LEGAL_BENCHMARK_SWEEP_SCHEMA_VERSION,
+        sweep_id: format!("sweep.{}", matrix.matrix_id),
+        scope: matrix.scope.clone(),
+        task_ids: matrix.task_ids.clone(),
+        run_config_hashes: run_configs
+            .iter()
+            .map(|config| config.run_config_hash.clone())
+            .collect(),
+        max_parallelism: matrix.max_parallelism,
+        budget: matrix.budget.clone(),
+        metadata: matrix.metadata.clone(),
+    };
+    Ok(LegalBenchmarkSweepMatrixPlan {
+        schema_version: LEGAL_BENCHMARK_SWEEP_SCHEMA_VERSION,
+        matrix_id: matrix.matrix_id.clone(),
+        sweep_config,
+        run_configs,
+    })
 }
 
 pub fn plan_legal_benchmark_sweep_jobs(
@@ -235,6 +391,51 @@ pub fn legal_benchmark_sweep_manifest_hash(
     stable_json_digest("psionic.legal_benchmark.sweep_manifest.v1", manifest)
 }
 
+pub fn legal_benchmark_sweep_matrix_config_hash(
+    matrix: &LegalBenchmarkSweepMatrixConfig,
+) -> Result<String, serde_json::Error> {
+    stable_json_digest("psionic.legal_benchmark.sweep_matrix_config.v1", matrix)
+}
+
+pub fn legal_benchmark_sweep_matrix_run_config_hash(
+    run_config: &LegalBenchmarkSweepMatrixRunConfig,
+) -> Result<String, serde_json::Error> {
+    let mut canonical = run_config.clone();
+    canonical.run_config_hash.clear();
+    stable_json_digest(
+        "psionic.legal_benchmark.sweep_matrix_run_config.v1",
+        &canonical,
+    )
+}
+
+pub fn generate_legal_benchmark_sweep_matrix_export(
+    matrix_id: impl Into<String>,
+    manifest: &LegalBenchmarkSweepManifest,
+) -> Result<LegalBenchmarkSweepMatrixExport, serde_json::Error> {
+    let mut summaries = summarize_matrix_configs(manifest);
+    mark_pareto_front(summaries.as_mut_slice());
+    let pareto_front_config_hashes = summaries
+        .iter()
+        .filter(|summary| summary.pareto_front)
+        .map(|summary| summary.run_config_hash.clone())
+        .collect::<Vec<_>>();
+    let config_hashes = summaries
+        .iter()
+        .map(|summary| summary.run_config_hash.clone())
+        .collect::<Vec<_>>();
+    Ok(LegalBenchmarkSweepMatrixExport {
+        schema_version: LEGAL_BENCHMARK_SWEEP_SCHEMA_VERSION,
+        matrix_id: matrix_id.into(),
+        sweep_id: manifest.sweep_id.clone(),
+        generated_at_ms: now_ms(),
+        manifest_hash: legal_benchmark_sweep_manifest_hash(manifest)?,
+        config_hashes,
+        summaries,
+        pareto_front_config_hashes,
+        metadata: Metadata::new(),
+    })
+}
+
 fn scoped_task_ids(config: &LegalBenchmarkSweepConfig) -> Vec<String> {
     match &config.scope {
         LegalBenchmarkSweepScope::TaskIds(task_ids) => task_ids.clone(),
@@ -259,6 +460,9 @@ fn job_record_from_outcome(
         wall_time_ms: outcome.wall_time_ms,
         input_tokens: outcome.input_tokens,
         output_tokens: outcome.output_tokens,
+        all_pass: outcome.all_pass,
+        criterion_pass_rate_bps: outcome.criterion_pass_rate_bps,
+        document_coverage_bps: outcome.document_coverage_bps,
         failure_kind: outcome.failure_kind,
         failure_detail: outcome.failure_detail,
     }
@@ -280,6 +484,9 @@ fn blocked_job_record(
         wall_time_ms: 0,
         input_tokens: 0,
         output_tokens: 0,
+        all_pass: None,
+        criterion_pass_rate_bps: None,
+        document_coverage_bps: None,
         failure_kind: Some(String::from("budget")),
         failure_detail: Some(String::from("budget exhausted before starting job")),
     }
@@ -310,6 +517,116 @@ fn manifest_from_jobs(
         jobs,
         metadata: Metadata::new(),
     }
+}
+
+fn summarize_matrix_configs(
+    manifest: &LegalBenchmarkSweepManifest,
+) -> Vec<LegalBenchmarkSweepMatrixConfigSummary> {
+    let mut grouped = BTreeMap::<String, Vec<&LegalBenchmarkSweepJobRecord>>::new();
+    for job in &manifest.jobs {
+        grouped
+            .entry(job.run_config_hash.clone())
+            .or_default()
+            .push(job);
+    }
+    grouped
+        .into_iter()
+        .map(|(run_config_hash, jobs)| {
+            let total_jobs = u64::try_from(jobs.len()).unwrap_or(u64::MAX);
+            let succeeded_jobs = u64::try_from(
+                jobs.iter()
+                    .filter(|job| job.status == LegalBenchmarkSweepJobStatus::Succeeded)
+                    .count(),
+            )
+            .unwrap_or(u64::MAX);
+            let failed_jobs = u64::try_from(
+                jobs.iter()
+                    .filter(|job| job.status == LegalBenchmarkSweepJobStatus::Failed)
+                    .count(),
+            )
+            .unwrap_or(u64::MAX);
+            let all_pass_count =
+                u64::try_from(jobs.iter().filter(|job| job.all_pass == Some(true)).count())
+                    .unwrap_or(u64::MAX);
+            let criterion_sum = jobs
+                .iter()
+                .filter_map(|job| job.criterion_pass_rate_bps)
+                .map(u64::from)
+                .sum::<u64>();
+            let document_sum = jobs
+                .iter()
+                .filter_map(|job| job.document_coverage_bps)
+                .map(u64::from)
+                .sum::<u64>();
+            let scored_count = u64::try_from(
+                jobs.iter()
+                    .filter(|job| job.criterion_pass_rate_bps.is_some())
+                    .count(),
+            )
+            .unwrap_or(0);
+            let total_cost_micro_usd = jobs.iter().map(|job| job.cost_micro_usd).sum();
+            let wall_time_sum = jobs.iter().map(|job| job.wall_time_ms).sum::<u64>();
+            LegalBenchmarkSweepMatrixConfigSummary {
+                run_config_hash,
+                total_jobs,
+                succeeded_jobs,
+                failed_jobs,
+                all_pass_rate_bps: ratio_bps(all_pass_count, total_jobs),
+                criterion_pass_rate_bps: average_bps(criterion_sum, scored_count),
+                document_coverage_bps: average_bps(document_sum, scored_count),
+                reliability_bps: ratio_bps(succeeded_jobs, total_jobs),
+                total_cost_micro_usd,
+                avg_wall_time_ms: if total_jobs == 0 {
+                    0
+                } else {
+                    wall_time_sum / total_jobs
+                },
+                input_tokens: jobs.iter().map(|job| job.input_tokens).sum(),
+                output_tokens: jobs.iter().map(|job| job.output_tokens).sum(),
+                pareto_front: false,
+            }
+        })
+        .collect()
+}
+
+fn mark_pareto_front(summaries: &mut [LegalBenchmarkSweepMatrixConfigSummary]) {
+    let snapshot = summaries.to_vec();
+    for summary in summaries {
+        summary.pareto_front = !snapshot.iter().any(|other| {
+            other.run_config_hash != summary.run_config_hash && dominates(other, summary)
+        });
+    }
+}
+
+fn dominates(
+    candidate: &LegalBenchmarkSweepMatrixConfigSummary,
+    incumbent: &LegalBenchmarkSweepMatrixConfigSummary,
+) -> bool {
+    let at_least_as_good = candidate.all_pass_rate_bps >= incumbent.all_pass_rate_bps
+        && candidate.criterion_pass_rate_bps >= incumbent.criterion_pass_rate_bps
+        && candidate.reliability_bps >= incumbent.reliability_bps
+        && candidate.total_cost_micro_usd <= incumbent.total_cost_micro_usd
+        && candidate.avg_wall_time_ms <= incumbent.avg_wall_time_ms;
+    let strictly_better = candidate.all_pass_rate_bps > incumbent.all_pass_rate_bps
+        || candidate.criterion_pass_rate_bps > incumbent.criterion_pass_rate_bps
+        || candidate.reliability_bps > incumbent.reliability_bps
+        || candidate.total_cost_micro_usd < incumbent.total_cost_micro_usd
+        || candidate.avg_wall_time_ms < incumbent.avg_wall_time_ms;
+    at_least_as_good && strictly_better
+}
+
+fn ratio_bps(numerator: u64, denominator: u64) -> u32 {
+    if denominator == 0 {
+        return 0;
+    }
+    u32::try_from((numerator * 10_000) / denominator).unwrap_or(0)
+}
+
+fn average_bps(sum: u64, count: u64) -> u32 {
+    if count == 0 {
+        return 0;
+    }
+    u32::try_from(sum / count).unwrap_or(0)
 }
 
 #[derive(Default)]
@@ -413,6 +730,69 @@ mod tests {
         }
     }
 
+    fn matrix_config() -> LegalBenchmarkSweepMatrixConfig {
+        LegalBenchmarkSweepMatrixConfig {
+            schema_version: LEGAL_BENCHMARK_SWEEP_SCHEMA_VERSION,
+            matrix_id: String::from("matrix.mock"),
+            scope: LegalBenchmarkSweepScope::Slice {
+                name: String::from("smoke"),
+                task_ids: vec![String::from("task.a")],
+            },
+            task_ids: Vec::new(),
+            providers: vec![
+                LegalBenchmarkSweepProviderAxis {
+                    provider_id: String::from("hosted"),
+                    provider_family: String::from("openai_compatible"),
+                    model: String::from("hosted-large"),
+                    route_id: String::from("route.hosted"),
+                },
+                LegalBenchmarkSweepProviderAxis {
+                    provider_id: String::from("local"),
+                    provider_family: String::from("psionic_compatible"),
+                    model: String::from("local-rust"),
+                    route_id: String::from("route.local"),
+                },
+            ],
+            reasoning_efforts: vec![
+                LegalBenchmarkSweepNamedAxis {
+                    id: String::from("standard"),
+                    metadata: Metadata::new(),
+                },
+                LegalBenchmarkSweepNamedAxis {
+                    id: String::from("deep"),
+                    metadata: Metadata::new(),
+                },
+            ],
+            context_budgets: vec![LegalBenchmarkSweepContextBudgetAxis {
+                id: String::from("32k"),
+                max_input_tokens: 32_000,
+                max_output_tokens: 4_000,
+            }],
+            extraction_policies: vec![LegalBenchmarkSweepNamedAxis {
+                id: String::from("native-first"),
+                metadata: Metadata::new(),
+            }],
+            tool_policies: vec![
+                LegalBenchmarkSweepNamedAxis {
+                    id: String::from("basic"),
+                    metadata: Metadata::new(),
+                },
+                LegalBenchmarkSweepNamedAxis {
+                    id: String::from("document-tools"),
+                    metadata: Metadata::new(),
+                },
+            ],
+            max_parallelism: 2,
+            budget: LegalBenchmarkSweepBudget {
+                max_cost_micro_usd: Some(1_000),
+                max_wall_time_ms: Some(10_000),
+                max_tokens: Some(100_000),
+                max_failures: Some(3),
+            },
+            metadata: Metadata::new(),
+        }
+    }
+
     #[test]
     fn plans_cross_product_jobs_for_slice_scope() {
         let jobs = plan_legal_benchmark_sweep_jobs(&config());
@@ -436,6 +816,9 @@ mod tests {
             wall_time_ms: 4,
             input_tokens: 5,
             output_tokens: 6,
+            all_pass: Some(true),
+            criterion_pass_rate_bps: Some(10_000),
+            document_coverage_bps: Some(10_000),
             failure_kind: None,
             failure_detail: None,
         };
@@ -451,6 +834,9 @@ mod tests {
                 wall_time_ms: 3,
                 input_tokens: 4,
                 output_tokens: 5,
+                all_pass: Some(false),
+                criterion_pass_rate_bps: Some(5_000),
+                document_coverage_bps: Some(8_000),
                 failure_kind: Some(String::from("provider_failure")),
                 failure_detail: Some(String::from("mock failure")),
             },
@@ -479,5 +865,112 @@ mod tests {
         let manifest = run_legal_benchmark_sweep(&cfg, None, &mut executor).expect("sweep");
         assert_eq!(manifest.succeeded_jobs, 1);
         assert!(manifest.budget_exhausted_jobs >= 1);
+    }
+
+    #[test]
+    fn matrix_expands_provider_reasoning_context_extraction_and_tool_axes() {
+        let plan = expand_legal_benchmark_sweep_matrix(&matrix_config()).expect("matrix plan");
+        assert_eq!(plan.run_configs.len(), 8);
+        assert_eq!(plan.sweep_config.run_config_hashes.len(), 8);
+        assert!(
+            plan.run_configs
+                .iter()
+                .any(|config| config.tool_policy_id == "document-tools")
+        );
+        assert!(legal_benchmark_sweep_matrix_config_hash(&matrix_config()).is_ok());
+    }
+
+    #[test]
+    fn matrix_smoke_fixture_expands_to_recorded_config_hashes() {
+        let matrix: LegalBenchmarkSweepMatrixConfig = serde_json::from_str(include_str!(
+            "../../../fixtures/legal_benchmark/sweep_matrix_smoke_config.json"
+        ))
+        .expect("matrix fixture parses");
+        let plan = expand_legal_benchmark_sweep_matrix(&matrix).expect("matrix plan");
+        assert_eq!(plan.run_configs.len(), 8);
+        assert!(
+            plan.sweep_config
+                .run_config_hashes
+                .iter()
+                .all(|hash| hash.len() == 64)
+        );
+    }
+
+    #[test]
+    fn matrix_export_marks_pareto_front_configs() {
+        let manifest = LegalBenchmarkSweepManifest {
+            schema_version: LEGAL_BENCHMARK_SWEEP_SCHEMA_VERSION,
+            sweep_id: String::from("sweep.matrix.mock"),
+            config_hash: String::from("matrix-hash"),
+            generated_at_ms: 1,
+            total_jobs: 6,
+            skipped_jobs: 0,
+            resumed_jobs: 0,
+            succeeded_jobs: 6,
+            failed_jobs: 0,
+            blocked_jobs: 0,
+            budget_exhausted_jobs: 0,
+            total_cost_micro_usd: 0,
+            total_wall_time_ms: 0,
+            total_input_tokens: 0,
+            total_output_tokens: 0,
+            jobs: vec![
+                scored_job("config.fast", "task.a", false, 9_000, 10, 10),
+                scored_job("config.fast", "task.b", false, 9_000, 10, 10),
+                scored_job("config.slow", "task.a", false, 9_000, 20, 20),
+                scored_job("config.slow", "task.b", false, 9_000, 20, 20),
+                scored_job("config.accurate", "task.a", true, 10_000, 40, 30),
+                scored_job("config.accurate", "task.b", true, 10_000, 40, 30),
+            ],
+            metadata: Metadata::new(),
+        };
+        let export =
+            generate_legal_benchmark_sweep_matrix_export("matrix.mock", &manifest).expect("export");
+        assert_eq!(export.config_hashes.len(), 3);
+        assert!(
+            export
+                .pareto_front_config_hashes
+                .contains(&String::from("config.fast"))
+        );
+        assert!(
+            export
+                .pareto_front_config_hashes
+                .contains(&String::from("config.accurate"))
+        );
+        assert!(
+            !export
+                .pareto_front_config_hashes
+                .contains(&String::from("config.slow"))
+        );
+    }
+
+    fn scored_job(
+        run_config_hash: &str,
+        task_id: &str,
+        all_pass: bool,
+        criterion_pass_rate_bps: u32,
+        cost_micro_usd: u64,
+        wall_time_ms: u64,
+    ) -> LegalBenchmarkSweepJobRecord {
+        LegalBenchmarkSweepJobRecord {
+            job_id: format!("job.{task_id}.{run_config_hash}"),
+            task_id: task_id.to_string(),
+            run_config_hash: run_config_hash.to_string(),
+            status: LegalBenchmarkSweepJobStatus::Succeeded,
+            run_id: Some(format!("run.{task_id}.{run_config_hash}")),
+            score_report_id: Some(format!("score.{task_id}.{run_config_hash}")),
+            score_report_hash: Some(String::from(
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            )),
+            cost_micro_usd,
+            wall_time_ms,
+            input_tokens: 100,
+            output_tokens: 20,
+            all_pass: Some(all_pass),
+            criterion_pass_rate_bps: Some(criterion_pass_rate_bps),
+            document_coverage_bps: Some(10_000),
+            failure_kind: None,
+            failure_detail: None,
+        }
     }
 }

--- a/docs/LEGAL_BENCHMARK_CI.md
+++ b/docs/LEGAL_BENCHMARK_CI.md
@@ -21,6 +21,7 @@ The check script runs:
 - sandbox traversal and symlink escape checks
 - mock report generation checks
 - mock sweep manifest checks
+- mock sweep matrix fixture validation
 - JSON validation for the legal benchmark fixtures used by the runner,
   evaluator, report, and sweep path
 

--- a/docs/LEGAL_BENCHMARK_ENGINE.md
+++ b/docs/LEGAL_BENCHMARK_ENGINE.md
@@ -233,10 +233,15 @@ without live provider credentials.
 Sweep planning and manifests are documented in `docs/LEGAL_BENCHMARK_SWEEPS.md`
 and implemented in `crates/psionic-eval/src/legal_benchmark_sweeps.rs`.
 
-The sweep layer plans task/config jobs, applies resume state, enforces cost,
+The sweep layer plans task/config jobs, expands provider/reasoning/context/
+extraction/tool-policy matrices, applies resume state, enforces cost,
 wall-time, token, and failure budgets, keeps going through individual
 task/model failures, and emits a manifest with skipped, resumed, succeeded,
 failed, blocked, and budget-exhausted job states for Autopilot4 import.
+
+Matrix exports summarize every recorded config hash by all-pass score,
+criterion pass rate, document coverage, reliability, cost, and latency, then
+mark Pareto-front configs for promotion-gate review.
 
 ## CI And Golden Fixtures
 
@@ -250,6 +255,5 @@ and exercises mock report and sweep fixtures without live provider credentials.
 
 ## Next Work
 
-The next implementation issue is model and tool-policy sweep matrices for
-measuring which document-tool policies and provider routes produce better
-scores under explicit cost, latency, and reliability budgets.
+The next implementation issue is production regression guardrails before
+benchmark-optimized modules can affect Autopilot agents.

--- a/docs/LEGAL_BENCHMARK_SWEEPS.md
+++ b/docs/LEGAL_BENCHMARK_SWEEPS.md
@@ -21,6 +21,20 @@ The first implementation plans jobs from the configured task ids and
 run-config hashes. The executor boundary is trait-based so live agent/evaluator
 execution can attach without changing the manifest schema.
 
+## Matrix Configs
+
+`LegalBenchmarkSweepMatrixConfig` expands provider, model, reasoning-effort,
+context-budget, extraction-policy, and tool-policy axes into pinned
+`run_config_hashes`. The matrix plan becomes a normal `LegalBenchmarkSweepConfig`
+so it still uses the same resumable runner and budget behavior.
+
+The checked fixture is:
+
+- `fixtures/legal_benchmark/sweep_matrix_smoke_config.json`
+
+It covers hosted, local/Psionic-compatible, reasoning-effort, context-budget,
+native-extraction, and document-tool policy axes.
+
 ## Budgets And Resume
 
 `LegalBenchmarkSweepBudget` can cap:
@@ -34,6 +48,25 @@ Completed jobs from `LegalBenchmarkSweepResumeState` become `resumed`.
 Failures become `failed` and do not stop unrelated jobs until the failure
 budget is exhausted. Budget exhaustion marks new jobs `budget_exhausted`
 instead of dropping them from the manifest.
+
+## Pareto Export
+
+`generate_legal_benchmark_sweep_matrix_export` groups manifest jobs by recorded
+config hash and computes:
+
+- all-pass rate
+- criterion pass rate
+- document coverage
+- reliability
+- total cost
+- average wall time
+- token totals
+- Pareto-front membership
+
+Pareto dominance maximizes all-pass, criterion pass rate, and reliability while
+minimizing cost and latency. Autopilot4 should promote only from recorded config
+hashes in this export; expensive or failed configs remain inspectable but do
+not silently become defaults.
 
 ## Command
 

--- a/fixtures/legal_benchmark/sweep_matrix_smoke_config.json
+++ b/fixtures/legal_benchmark/sweep_matrix_smoke_config.json
@@ -1,0 +1,60 @@
+{
+  "schema_version": 1,
+  "matrix_id": "matrix.mock.smoke",
+  "scope": {
+    "slice": {
+      "name": "smoke",
+      "task_ids": ["task.a", "task.b"]
+    }
+  },
+  "task_ids": [],
+  "providers": [
+    {
+      "provider_id": "hosted",
+      "provider_family": "openai_compatible",
+      "model": "hosted-large",
+      "route_id": "route.hosted"
+    },
+    {
+      "provider_id": "local",
+      "provider_family": "psionic_compatible",
+      "model": "local-rust",
+      "route_id": "route.local"
+    }
+  ],
+  "reasoning_efforts": [
+    {
+      "id": "standard"
+    },
+    {
+      "id": "deep"
+    }
+  ],
+  "context_budgets": [
+    {
+      "id": "32k",
+      "max_input_tokens": 32000,
+      "max_output_tokens": 4000
+    }
+  ],
+  "extraction_policies": [
+    {
+      "id": "native-first"
+    }
+  ],
+  "tool_policies": [
+    {
+      "id": "basic"
+    },
+    {
+      "id": "document-tools"
+    }
+  ],
+  "max_parallelism": 2,
+  "budget": {
+    "max_cost_micro_usd": 1000,
+    "max_wall_time_ms": 10000,
+    "max_tokens": 100000,
+    "max_failures": 3
+  }
+}

--- a/scripts/check-legal-benchmark-ci.sh
+++ b/scripts/check-legal-benchmark-ci.sh
@@ -15,3 +15,4 @@ python3 -m json.tool fixtures/legal_benchmark/normalization_snapshot_minimal.jso
 python3 -m json.tool fixtures/legal_benchmark/evaluator_mock_score_report.json >/dev/null
 python3 -m json.tool fixtures/legal_benchmark/report_export_mock.json >/dev/null
 python3 -m json.tool fixtures/legal_benchmark/sweep_smoke_config.json >/dev/null
+python3 -m json.tool fixtures/legal_benchmark/sweep_matrix_smoke_config.json >/dev/null


### PR DESCRIPTION
Summary:
- Adds sweep matrix configs across provider, reasoning, context, extraction, and tool-policy axes.
- Expands matrices into normal resumable sweep configs with pinned run config hashes.
- Adds score-bearing sweep job records and Pareto-front export by all-pass score, criterion pass rate, reliability, cost, and latency.
- Adds smoke matrix fixture plus docs and CI fixture validation.

Validation:
- scripts/check-legal-benchmark-ci.sh
- cargo test -p psionic-eval --no-default-features --lib legal_benchmark_sweeps
- cargo test -p psionic-eval --no-default-features --lib
- cargo test -p psionic-eval --lib legal_benchmark_sweeps
- git diff --cached --check

Closes #1000