### PR TITLE
Add Qwen3.6-35B-A3B MoE-safe smoke

### DIFF
--- a/configs/legal/qwen36_35b_a3b_sft_smoke.json
+++ b/configs/legal/qwen36_35b_a3b_sft_smoke.json
@@ -1,0 +1,93 @@
+{
+  "schema_version": "psionic.legal_sft_config.v1",
+  "run_id": "qwen36-35b-a3b-legal-sft-smoke",
+  "train_type": "qlora",
+  "base_model": "Qwen/Qwen3.6-35B-A3B",
+  "served_model_id": "qwen3.6-35b-a3b",
+  "base_model_revision": "qwen3.6-35b-a3b-smoke-revision",
+  "base_artifact_mode": "synthetic_hidden_state_smoke",
+  "base_served_artifact_digest": "sha256:synthetic-qwen36-35b-a3b-legal-smoke",
+  "model_config_path": "fixtures/qwen36_35b_a3b_smoke/config.json",
+  "tokenizer_path": "fixtures/qwen36_27b_smoke/tokenizer.json",
+  "tokenizer_digest": "sha256:qwen36-35b-a3b-tokenizer-smoke",
+  "prompt_template_digest": "sha256:qwen36-chat-template-v1-smoke",
+  "hidden_size": 4,
+  "vocab_size": 256,
+  "adapter_target_id": "lm_head",
+  "target_modules": ["q_proj", "k_proj", "v_proj", "o_proj", "up_proj", "down_proj"],
+  "moe_safety": {
+    "target_model": "Qwen/Qwen3.6-35B-A3B",
+    "router_frozen": true,
+    "frozen_parameter_patterns": ["router", ".gate."],
+    "allowed_lora_target_modules": ["q_proj", "k_proj", "v_proj", "o_proj", "up_proj", "down_proj"],
+    "forbidden_lora_target_substrings": ["router", "gate"],
+    "expert_safetensors_path": "target/legal/qwen36_35b_a3b_sft_smoke/moe_expert_smoke.safetensors",
+    "expected_expert_count": 128,
+    "active_expert_ids": [0, 1],
+    "expert_usage_counts": [4, 4],
+    "dense_champion_ref": "target/legal/qwen36_27b_sft_smoke/adapter.safetensors"
+  },
+  "lora_rank": 16,
+  "lora_alpha": 32.0,
+  "lora_dropout": 0.0,
+  "learning_rate": 0.12,
+  "epochs": 1,
+  "max_seq_len": 8192,
+  "gradient_accumulation_steps": 8,
+  "max_steps": 8,
+  "batch_size": 2,
+  "assistant_only_loss": true,
+  "ignore_empty_think_loss": true,
+  "gradient_clip_norm": 1.0,
+  "started_at_ms": 1000,
+  "step_duration_ms": 20,
+  "dataset_ref": "dataset://openagents/legal-benchmark/harvey-smoke@v1",
+  "validator_policy_ref": "policy://validator/legal-benchmark/qwen36-35b-a3b-smoke",
+  "adapter_id": "qwen36-35b-a3b-legal-moe-safe-smoke",
+  "adapter_revision": "r1",
+  "output_dir": "target/legal/qwen36_35b_a3b_sft_smoke",
+  "samples": [
+    {
+      "sample_id": "legal-smoke-a",
+      "legal_training_record_id": "legal-record-a",
+      "final_hidden_state": [1.0, 0.0, 0.0, 0.0],
+      "target_token_id": 12,
+      "source_token_count": 41
+    },
+    {
+      "sample_id": "legal-smoke-b",
+      "legal_training_record_id": "legal-record-b",
+      "final_hidden_state": [0.0, 1.0, 0.0, 0.0],
+      "target_token_id": 35,
+      "source_token_count": 39
+    },
+    {
+      "sample_id": "legal-smoke-c",
+      "legal_training_record_id": "legal-record-c",
+      "final_hidden_state": [0.0, 0.0, 1.0, 0.0],
+      "target_token_id": 62,
+      "source_token_count": 47
+    },
+    {
+      "sample_id": "legal-smoke-d",
+      "legal_training_record_id": "legal-record-d",
+      "final_hidden_state": [0.0, 0.0, 0.0, 1.0],
+      "target_token_id": 90,
+      "source_token_count": 44
+    },
+    {
+      "sample_id": "legal-smoke-e",
+      "legal_training_record_id": "legal-record-e",
+      "final_hidden_state": [0.6, 0.4, 0.0, 0.0],
+      "target_token_id": 118,
+      "source_token_count": 52
+    },
+    {
+      "sample_id": "legal-smoke-f",
+      "legal_training_record_id": "legal-record-f",
+      "final_hidden_state": [0.0, 0.2, 0.5, 0.3],
+      "target_token_id": 143,
+      "source_token_count": 49
+    }
+  ]
+}

--- a/crates/psionic-models/src/qwen36.rs
+++ b/crates/psionic-models/src/qwen36.rs
@@ -20,6 +20,13 @@ pub const QWEN36_27B_SMOKE_CONFIG_PATH: &str = "fixtures/qwen36_27b_smoke/config
 pub const QWEN36_27B_SMOKE_TOKENIZER_PATH: &str = "fixtures/qwen36_27b_smoke/tokenizer.json";
 pub const QWEN36_27B_SMOKE_SHARD_PATH: &str =
     "target/legal/qwen36_27b_prompt_smoke/model-00001-of-00001.safetensors";
+pub const QWEN36_35B_A3B_MODEL_ID: &str = "Qwen/Qwen3.6-35B-A3B";
+pub const QWEN36_35B_A3B_SHORT_MODEL_ID: &str = "Qwen3.6-35B-A3B";
+pub const QWEN36_35B_A3B_SERVED_MODEL_ID: &str = "qwen3.6-35b-a3b";
+pub const QWEN36_35B_A3B_SMOKE_CONFIG_PATH: &str = "fixtures/qwen36_35b_a3b_smoke/config.json";
+pub const QWEN36_35B_A3B_SMOKE_TOKENIZER_PATH: &str = "fixtures/qwen36_27b_smoke/tokenizer.json";
+pub const QWEN36_35B_A3B_SMOKE_SHARD_PATH: &str =
+    "target/legal/qwen36_35b_a3b_prompt_smoke/model-00001-of-00001.safetensors";
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -47,6 +54,12 @@ pub struct Qwen36ModelConfig {
     pub tokenizer_path: String,
     pub chat_template_id: String,
     pub memory_strategy: Qwen36TargetMemoryStrategy,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub num_experts: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub num_experts_per_tok: Option<usize>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub moe_intermediate_size: Option<usize>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
@@ -196,6 +209,29 @@ pub fn normalize_qwen36_27b_model_id(model: &str) -> Result<String, Qwen36Target
     }
 }
 
+pub fn normalize_qwen36_35b_a3b_model_id(model: &str) -> Result<String, Qwen36TargetPathError> {
+    match model {
+        QWEN36_35B_A3B_MODEL_ID | QWEN36_35B_A3B_SHORT_MODEL_ID => {
+            Ok(String::from(QWEN36_35B_A3B_MODEL_ID))
+        }
+        other => Err(Qwen36TargetPathError::InvalidTargetModel(String::from(
+            other,
+        ))),
+    }
+}
+
+pub fn normalize_qwen36_target_model_id(model: &str) -> Result<String, Qwen36TargetPathError> {
+    match model {
+        QWEN36_27B_MODEL_ID | QWEN36_27B_SHORT_MODEL_ID => Ok(String::from(QWEN36_27B_MODEL_ID)),
+        QWEN36_35B_A3B_MODEL_ID | QWEN36_35B_A3B_SHORT_MODEL_ID => {
+            Ok(String::from(QWEN36_35B_A3B_MODEL_ID))
+        }
+        other => Err(Qwen36TargetPathError::InvalidTargetModel(String::from(
+            other,
+        ))),
+    }
+}
+
 pub fn load_qwen36_model_config(
     path: impl AsRef<Path>,
 ) -> Result<Qwen36ModelConfig, Qwen36TargetPathError> {
@@ -212,10 +248,17 @@ pub fn load_qwen36_model_config(
 pub fn validate_qwen36_model_config(
     config: &Qwen36ModelConfig,
 ) -> Result<(), Qwen36TargetPathError> {
-    normalize_qwen36_27b_model_id(config.model_id.as_str())?;
-    if config.served_model_id != QWEN36_27B_SERVED_MODEL_ID {
+    let model_id = normalize_qwen36_target_model_id(config.model_id.as_str())?;
+    if model_id == QWEN36_27B_MODEL_ID && config.served_model_id != QWEN36_27B_SERVED_MODEL_ID {
         return Err(Qwen36TargetPathError::InvalidConfig(String::from(
             "served_model_id must be qwen3.6-27b",
+        )));
+    }
+    if model_id == QWEN36_35B_A3B_MODEL_ID
+        && config.served_model_id != QWEN36_35B_A3B_SERVED_MODEL_ID
+    {
+        return Err(Qwen36TargetPathError::InvalidConfig(String::from(
+            "served_model_id must be qwen3.6-35b-a3b",
         )));
     }
     if config.model_type != "qwen3" {
@@ -223,13 +266,23 @@ pub fn validate_qwen36_model_config(
             "model_type must be qwen3",
         )));
     }
-    if !config
+    if model_id == QWEN36_27B_MODEL_ID {
+        if !config
+            .architectures
+            .iter()
+            .any(|architecture| architecture == "Qwen3ForCausalLM")
+        {
+            return Err(Qwen36TargetPathError::InvalidConfig(String::from(
+                "27B architectures must include Qwen3ForCausalLM",
+            )));
+        }
+    } else if !config
         .architectures
         .iter()
-        .any(|architecture| architecture == "Qwen3ForCausalLM")
+        .any(|architecture| architecture == "Qwen3MoeForCausalLM")
     {
         return Err(Qwen36TargetPathError::InvalidConfig(String::from(
-            "architectures must include Qwen3ForCausalLM",
+            "35B-A3B architectures must include Qwen3MoeForCausalLM",
         )));
     }
     if config.hidden_size == 0
@@ -253,6 +306,33 @@ pub fn validate_qwen36_model_config(
         return Err(Qwen36TargetPathError::InvalidConfig(String::from(
             "chat_template_id must match qwen3.6.chat_template.v1",
         )));
+    }
+    if model_id == QWEN36_35B_A3B_MODEL_ID {
+        let Some(num_experts) = config.num_experts else {
+            return Err(Qwen36TargetPathError::InvalidConfig(String::from(
+                "35B-A3B MoE config must declare num_experts",
+            )));
+        };
+        let Some(num_experts_per_tok) = config.num_experts_per_tok else {
+            return Err(Qwen36TargetPathError::InvalidConfig(String::from(
+                "35B-A3B MoE config must declare num_experts_per_tok",
+            )));
+        };
+        let Some(moe_intermediate_size) = config.moe_intermediate_size else {
+            return Err(Qwen36TargetPathError::InvalidConfig(String::from(
+                "35B-A3B MoE config must declare moe_intermediate_size",
+            )));
+        };
+        if num_experts == 0 || num_experts_per_tok == 0 || moe_intermediate_size == 0 {
+            return Err(Qwen36TargetPathError::InvalidConfig(String::from(
+                "35B-A3B MoE dimensions must be non-zero",
+            )));
+        }
+        if num_experts_per_tok > num_experts {
+            return Err(Qwen36TargetPathError::InvalidConfig(String::from(
+                "num_experts_per_tok cannot exceed num_experts",
+            )));
+        }
     }
     Ok(())
 }
@@ -312,6 +392,81 @@ pub fn load_qwen36_safetensors_shard(
     })
 }
 
+pub fn write_qwen36_35b_a3b_moe_smoke_safetensors(
+    path: impl AsRef<Path>,
+) -> Result<Qwen36LoadedShardReport, Qwen36TargetPathError> {
+    let path = path.as_ref();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|source| Qwen36TargetPathError::Io {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let router = encode_f32_bytes(&[0.2, 0.8, 0.6, 0.4, 0.3, 0.7, 0.9, 0.1]);
+    let expert_0_gate = encode_f32_bytes(&[0.1, 0.2, 0.3, 0.4]);
+    let expert_0_up = encode_f32_bytes(&[0.4, 0.3, 0.2, 0.1]);
+    let expert_0_down = encode_f32_bytes(&[0.5, 0.6, 0.7, 0.8]);
+    let expert_1_gate = encode_f32_bytes(&[0.8, 0.7, 0.6, 0.5]);
+    let expert_1_up = encode_f32_bytes(&[0.5, 0.6, 0.7, 0.8]);
+    let expert_1_down = encode_f32_bytes(&[0.4, 0.3, 0.2, 0.1]);
+    let router_view = TensorView::new(SafeTensorsDType::F32, vec![2, 4], router.as_slice())
+        .map_err(|error| Qwen36TargetPathError::SafeTensors(error.to_string()))?;
+    let expert_0_gate_view =
+        TensorView::new(SafeTensorsDType::F32, vec![2, 2], expert_0_gate.as_slice())
+            .map_err(|error| Qwen36TargetPathError::SafeTensors(error.to_string()))?;
+    let expert_0_up_view =
+        TensorView::new(SafeTensorsDType::F32, vec![2, 2], expert_0_up.as_slice())
+            .map_err(|error| Qwen36TargetPathError::SafeTensors(error.to_string()))?;
+    let expert_0_down_view =
+        TensorView::new(SafeTensorsDType::F32, vec![2, 2], expert_0_down.as_slice())
+            .map_err(|error| Qwen36TargetPathError::SafeTensors(error.to_string()))?;
+    let expert_1_gate_view =
+        TensorView::new(SafeTensorsDType::F32, vec![2, 2], expert_1_gate.as_slice())
+            .map_err(|error| Qwen36TargetPathError::SafeTensors(error.to_string()))?;
+    let expert_1_up_view =
+        TensorView::new(SafeTensorsDType::F32, vec![2, 2], expert_1_up.as_slice())
+            .map_err(|error| Qwen36TargetPathError::SafeTensors(error.to_string()))?;
+    let expert_1_down_view =
+        TensorView::new(SafeTensorsDType::F32, vec![2, 2], expert_1_down.as_slice())
+            .map_err(|error| Qwen36TargetPathError::SafeTensors(error.to_string()))?;
+    let bytes = serialize(
+        [
+            ("model.layers.0.mlp.gate.weight", router_view),
+            (
+                "model.layers.0.mlp.experts.0.gate_proj.weight",
+                expert_0_gate_view,
+            ),
+            (
+                "model.layers.0.mlp.experts.0.up_proj.weight",
+                expert_0_up_view,
+            ),
+            (
+                "model.layers.0.mlp.experts.0.down_proj.weight",
+                expert_0_down_view,
+            ),
+            (
+                "model.layers.0.mlp.experts.1.gate_proj.weight",
+                expert_1_gate_view,
+            ),
+            (
+                "model.layers.0.mlp.experts.1.up_proj.weight",
+                expert_1_up_view,
+            ),
+            (
+                "model.layers.0.mlp.experts.1.down_proj.weight",
+                expert_1_down_view,
+            ),
+        ],
+        None,
+    )
+    .map_err(|error| Qwen36TargetPathError::SafeTensors(error.to_string()))?;
+    fs::write(path, bytes).map_err(|source| Qwen36TargetPathError::Io {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    load_qwen36_safetensors_shard(path)
+}
+
 pub fn run_qwen36_legal_prompt_smoke(
     model: &str,
     prompt_path: impl AsRef<Path>,
@@ -319,12 +474,12 @@ pub fn run_qwen36_legal_prompt_smoke(
     tokenizer_path: impl AsRef<Path>,
     shard_paths: &[PathBuf],
 ) -> Result<Qwen36LegalPromptSmokeReport, Qwen36TargetPathError> {
-    let model_id = normalize_qwen36_27b_model_id(model)?;
+    let model_id = normalize_qwen36_target_model_id(model)?;
     let prompt_path = prompt_path.as_ref();
     let config_path = config_path.as_ref();
     let tokenizer_path = tokenizer_path.as_ref();
     let config = load_qwen36_model_config(config_path)?;
-    if normalize_qwen36_27b_model_id(config.model_id.as_str())? != model_id {
+    if normalize_qwen36_target_model_id(config.model_id.as_str())? != model_id {
         return Err(Qwen36TargetPathError::InvalidConfig(String::from(
             "requested model and config model_id differ",
         )));
@@ -362,13 +517,27 @@ pub fn run_qwen36_legal_prompt_smoke(
         )));
     }
     let deterministic_output = deterministic_qwen36_legal_smoke_output(
+        model_id.as_str(),
         rendered.prompt_hash.as_str(),
         loaded_shards.as_slice(),
     );
     let prompt_receipt = Qwen36PromptReceipt::from(&rendered);
     let rendered_prompt = rendered.text;
+    let claim_boundary = if model_id == QWEN36_35B_A3B_MODEL_ID {
+        String::from(
+            "This is a Rust Qwen3.6-35B-A3B MoE target-path smoke. It loads config, tokenizer, and expert safetensors shards, renders the Qwen3.6 direct-answer chat template, and emits deterministic local output. It does not claim full 35B-A3B weight inference, router training, or retained Harvey benchmark improvement.",
+        )
+    } else {
+        String::from(
+            "This is a Rust Qwen3.6-27B target-path smoke. It loads config, tokenizer, and safetensors shards, renders the Qwen3.6 direct-answer chat template, and emits deterministic local output. It does not claim full 27B weight inference.",
+        )
+    };
     Ok(Qwen36LegalPromptSmokeReport {
-        schema_version: String::from("psionic.qwen36_27b_legal_prompt_smoke.v1"),
+        schema_version: if model_id == QWEN36_35B_A3B_MODEL_ID {
+            String::from("psionic.qwen36_35b_a3b_legal_prompt_smoke.v1")
+        } else {
+            String::from("psionic.qwen36_27b_legal_prompt_smoke.v1")
+        },
         model_id,
         served_model_id: config.served_model_id,
         config_path: config_path.display().to_string(),
@@ -379,13 +548,12 @@ pub fn run_qwen36_legal_prompt_smoke(
         rendered_prompt,
         deterministic_output,
         memory_strategy: config.memory_strategy,
-        claim_boundary: String::from(
-            "This is a Rust Qwen3.6-27B target-path smoke. It loads config, tokenizer, and safetensors shards, renders the Qwen3.6 direct-answer chat template, and emits deterministic local output. It does not claim full 27B weight inference.",
-        ),
+        claim_boundary,
     })
 }
 
 fn deterministic_qwen36_legal_smoke_output(
+    model_id: &str,
     prompt_hash: &str,
     loaded_shards: &[Qwen36LoadedShardReport],
 ) -> String {
@@ -394,7 +562,7 @@ fn deterministic_qwen36_legal_smoke_output(
         .map(|shard| shard.sha256.as_str())
         .unwrap_or("missing");
     format!(
-        "Qwen3.6-27B legal smoke loaded {} shard(s), rendered prompt {}, and is ready for adapter evaluation. First shard hash: {}.",
+        "{model_id} legal smoke loaded {} shard(s), rendered prompt {}, and is ready for adapter evaluation. First shard hash: {}.",
         loaded_shards.len(),
         &prompt_hash[..12.min(prompt_hash.len())],
         &shard_hash[..12.min(shard_hash.len())]
@@ -674,6 +842,9 @@ mod tests {
             tokenizer_path: String::from(QWEN36_27B_SMOKE_TOKENIZER_PATH),
             chat_template_id: String::from(QWEN36_TEMPLATE_ID),
             memory_strategy: Qwen36TargetMemoryStrategy::CpuOffloadSmoke,
+            num_experts: None,
+            num_experts_per_tok: None,
+            moe_intermediate_size: None,
         };
 
         validate_qwen36_model_config(&config).expect("Qwen3.6-27B target config");
@@ -681,6 +852,55 @@ mod tests {
             normalize_qwen36_27b_model_id(QWEN36_27B_SHORT_MODEL_ID).expect("normalize"),
             QWEN36_27B_MODEL_ID
         );
+    }
+
+    #[test]
+    fn qwen36_35b_a3b_target_config_requires_moe_facts() {
+        let config = Qwen36ModelConfig {
+            model_id: String::from(QWEN36_35B_A3B_MODEL_ID),
+            served_model_id: String::from(QWEN36_35B_A3B_SERVED_MODEL_ID),
+            model_type: String::from("qwen3"),
+            architectures: vec![String::from("Qwen3MoeForCausalLM")],
+            hidden_size: 5120,
+            intermediate_size: 27648,
+            num_hidden_layers: 64,
+            num_attention_heads: 40,
+            num_key_value_heads: 8,
+            vocab_size: 151936,
+            max_position_embeddings: 131072,
+            torch_dtype: String::from("bfloat16"),
+            tokenizer_path: String::from(QWEN36_35B_A3B_SMOKE_TOKENIZER_PATH),
+            chat_template_id: String::from(QWEN36_TEMPLATE_ID),
+            memory_strategy: Qwen36TargetMemoryStrategy::PylonMultiWorker,
+            num_experts: Some(128),
+            num_experts_per_tok: Some(8),
+            moe_intermediate_size: Some(768),
+        };
+
+        validate_qwen36_model_config(&config).expect("Qwen3.6-35B-A3B MoE target config");
+        assert_eq!(
+            normalize_qwen36_35b_a3b_model_id(QWEN36_35B_A3B_SHORT_MODEL_ID).expect("normalize"),
+            QWEN36_35B_A3B_MODEL_ID
+        );
+    }
+
+    #[test]
+    fn qwen36_35b_a3b_moe_smoke_loads_router_and_expert_tensors() {
+        let temp = tempfile::tempdir().expect("tempdir");
+        let shard_path = temp.path().join("model-00001-of-00001.safetensors");
+
+        let report =
+            write_qwen36_35b_a3b_moe_smoke_safetensors(&shard_path).expect("write MoE shard");
+
+        assert!(report
+            .tensor_names
+            .contains(&String::from("model.layers.0.mlp.gate.weight")));
+        assert!(report.tensor_names.contains(&String::from(
+            "model.layers.0.mlp.experts.0.gate_proj.weight"
+        )));
+        assert!(report.tensor_names.contains(&String::from(
+            "model.layers.0.mlp.experts.1.down_proj.weight"
+        )));
     }
 
     #[test]

--- a/crates/psionic-serve/examples/qwen36_legal_prompt_smoke.rs
+++ b/crates/psionic-serve/examples/qwen36_legal_prompt_smoke.rs
@@ -1,24 +1,47 @@
 use std::{env, error::Error, io, path::PathBuf};
 
 use psionic_models::{
-    run_qwen36_legal_prompt_smoke, write_qwen36_27b_smoke_safetensors, QWEN36_27B_MODEL_ID,
-    QWEN36_27B_SMOKE_CONFIG_PATH, QWEN36_27B_SMOKE_SHARD_PATH, QWEN36_27B_SMOKE_TOKENIZER_PATH,
+    normalize_qwen36_target_model_id, run_qwen36_legal_prompt_smoke,
+    write_qwen36_27b_smoke_safetensors, write_qwen36_35b_a3b_moe_smoke_safetensors,
+    QWEN36_27B_MODEL_ID, QWEN36_27B_SMOKE_CONFIG_PATH, QWEN36_27B_SMOKE_SHARD_PATH,
+    QWEN36_27B_SMOKE_TOKENIZER_PATH, QWEN36_35B_A3B_MODEL_ID, QWEN36_35B_A3B_SMOKE_CONFIG_PATH,
+    QWEN36_35B_A3B_SMOKE_SHARD_PATH, QWEN36_35B_A3B_SMOKE_TOKENIZER_PATH,
 };
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args = env::args().collect::<Vec<_>>();
     let model =
         optional_flag(&args, "--model").unwrap_or_else(|| String::from(QWEN36_27B_MODEL_ID));
+    let normalized_model = normalize_qwen36_target_model_id(model.as_str())?;
     let prompt = required_flag(&args, "--prompt")?;
-    let config = optional_flag(&args, "--config")
-        .unwrap_or_else(|| String::from(QWEN36_27B_SMOKE_CONFIG_PATH));
-    let tokenizer = optional_flag(&args, "--tokenizer")
-        .unwrap_or_else(|| String::from(QWEN36_27B_SMOKE_TOKENIZER_PATH));
-    let shard = optional_flag(&args, "--shard")
-        .unwrap_or_else(|| String::from(QWEN36_27B_SMOKE_SHARD_PATH));
+    let config = optional_flag(&args, "--config").unwrap_or_else(|| {
+        if normalized_model == QWEN36_35B_A3B_MODEL_ID {
+            String::from(QWEN36_35B_A3B_SMOKE_CONFIG_PATH)
+        } else {
+            String::from(QWEN36_27B_SMOKE_CONFIG_PATH)
+        }
+    });
+    let tokenizer = optional_flag(&args, "--tokenizer").unwrap_or_else(|| {
+        if normalized_model == QWEN36_35B_A3B_MODEL_ID {
+            String::from(QWEN36_35B_A3B_SMOKE_TOKENIZER_PATH)
+        } else {
+            String::from(QWEN36_27B_SMOKE_TOKENIZER_PATH)
+        }
+    });
+    let shard = optional_flag(&args, "--shard").unwrap_or_else(|| {
+        if normalized_model == QWEN36_35B_A3B_MODEL_ID {
+            String::from(QWEN36_35B_A3B_SMOKE_SHARD_PATH)
+        } else {
+            String::from(QWEN36_27B_SMOKE_SHARD_PATH)
+        }
+    });
     let shard_path = PathBuf::from(&shard);
     if !shard_path.exists() {
-        write_qwen36_27b_smoke_safetensors(&shard_path)?;
+        if normalized_model == QWEN36_35B_A3B_MODEL_ID {
+            write_qwen36_35b_a3b_moe_smoke_safetensors(&shard_path)?;
+        } else {
+            write_qwen36_27b_smoke_safetensors(&shard_path)?;
+        }
     }
 
     let report = run_qwen36_legal_prompt_smoke(

--- a/crates/psionic-train/src/legal_sft_cli.rs
+++ b/crates/psionic-train/src/legal_sft_cli.rs
@@ -4,18 +4,22 @@ use std::{
 };
 
 use psionic_data::{TokenizerDigest, TokenizerFamily};
+use psionic_models::{
+    load_qwen36_safetensors_shard, normalize_qwen36_35b_a3b_model_id,
+    write_qwen36_35b_a3b_moe_smoke_safetensors, QWEN36_35B_A3B_MODEL_ID,
+};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 use crate::{
-    ModelIoArtifactReceipt, OPEN_ADAPTER_QWEN36_LEGAL_CUDA_BACKEND_LABEL,
-    OpenAdapterAdmissibleModelFamily, OpenAdapterExecutionConfig, OpenAdapterHiddenStateSample,
-    OpenAdapterLmHeadTarget, OpenAdapterPrecisionPolicy, OpenAdapterReferenceModel,
-    OpenAdapterSftError, OpenAdapterSftRunRequest, OpenAdapterTrainingExecutionBackend,
+    run_open_adapter_sft_export, ModelIoArtifactReceipt, OpenAdapterAdmissibleModelFamily,
+    OpenAdapterExecutionConfig, OpenAdapterHiddenStateSample, OpenAdapterLmHeadTarget,
+    OpenAdapterPrecisionPolicy, OpenAdapterReferenceModel, OpenAdapterSftError,
+    OpenAdapterSftRunRequest, OpenAdapterTrainingExecutionBackend,
     OpenAdapterTrainingExecutionError, TrainingCoreError, TrainingLoopBudget,
     TrainingOptimizerConfig, TrainingOptimizerResidencyPolicy, TrainingRunSummary,
-    TrainingStepReceipt, run_open_adapter_sft_export,
+    TrainingStepReceipt, OPEN_ADAPTER_QWEN36_LEGAL_CUDA_BACKEND_LABEL,
 };
 
 /// Config schema accepted by `psionic-train sft --config`.
@@ -88,6 +92,9 @@ pub struct PsionicLegalSftConfig {
     /// Declared future Qwen dense target modules or `all-linear`.
     #[serde(default)]
     pub target_modules: Vec<String>,
+    /// Optional MoE safety contract for Qwen3.6 sparse targets.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub moe_safety: Option<PsionicLegalSftMoeSafetyConfig>,
     /// LoRA rank.
     pub lora_rank: usize,
     /// LoRA alpha.
@@ -212,8 +219,34 @@ impl PsionicLegalSftConfig {
             });
         }
         resolve_qwen36_target_modules(&self.target_modules)?;
+        validate_moe_safety_config(self)?;
         Ok(())
     }
+}
+
+/// Guardrail contract for MoE legal SFT smokes.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PsionicLegalSftMoeSafetyConfig {
+    /// MoE target model id.
+    pub target_model: String,
+    /// Router/gating parameters must remain frozen.
+    pub router_frozen: bool,
+    /// Parameter name fragments treated as frozen router/gating state.
+    pub frozen_parameter_patterns: Vec<String>,
+    /// Explicit allowed LoRA target modules for this run.
+    pub allowed_lora_target_modules: Vec<String>,
+    /// Substrings that cannot appear in LoRA target module names.
+    pub forbidden_lora_target_substrings: Vec<String>,
+    /// Synthetic or real expert safetensors path to load for the smoke.
+    pub expert_safetensors_path: String,
+    /// Declared total expert count.
+    pub expected_expert_count: usize,
+    /// Experts activated by the tiny smoke route.
+    pub active_expert_ids: Vec<usize>,
+    /// Per-active-expert usage counts for the smoke route.
+    pub expert_usage_counts: Vec<u64>,
+    /// Dense champion adapter or report used as the comparison baseline.
+    pub dense_champion_ref: String,
 }
 
 /// Base artifact posture for one SFT run.
@@ -369,8 +402,13 @@ pub struct PsionicTrainingReceipt {
     pub prompt_template_digest: String,
     /// Smoke active trainable target.
     pub active_trainable_target: String,
+    /// Plain active-parameter path.
+    pub active_parameter_path: String,
     /// Resolved declared target modules.
     pub resolved_target_modules: Vec<String>,
+    /// Optional MoE safety receipt for sparse target runs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub moe_safety: Option<PsionicLegalSftMoeSafetyReceipt>,
     /// LoRA rank.
     pub lora_rank: usize,
     /// LoRA alpha.
@@ -409,6 +447,41 @@ pub struct PsionicTrainingReceipt {
     pub claim_boundary: String,
     /// Receipt digest.
     pub receipt_digest: String,
+}
+
+/// Machine-readable proof that a MoE run did not train router/gating state.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PsionicLegalSftMoeSafetyReceipt {
+    /// MoE target model id.
+    pub target_model: String,
+    /// Whether router/gating parameters were frozen.
+    pub router_frozen: bool,
+    /// Whether router/gating state is unchanged by this adapter-only smoke.
+    pub router_state_unchanged: bool,
+    /// Frozen parameter fragments.
+    pub frozen_parameter_patterns: Vec<String>,
+    /// Explicit allowed LoRA target modules.
+    pub allowed_lora_target_modules: Vec<String>,
+    /// LoRA target modules used by this run.
+    pub observed_lora_target_modules: Vec<String>,
+    /// Expert safetensors loaded by this run.
+    pub expert_safetensors_path: String,
+    /// Expert safetensors hash.
+    pub expert_safetensors_sha256: String,
+    /// Tensor names loaded from the expert shard.
+    pub expert_tensor_names: Vec<String>,
+    /// Declared total expert count.
+    pub expected_expert_count: usize,
+    /// Expert ids active in the tiny smoke route.
+    pub active_expert_ids: Vec<usize>,
+    /// Usage counts for the active experts.
+    pub expert_usage_counts: Vec<u64>,
+    /// Stable before hash for frozen router/gating state.
+    pub router_parameter_hash_before: String,
+    /// Stable after hash for frozen router/gating state.
+    pub router_parameter_hash_after: String,
+    /// Dense champion comparison target.
+    pub dense_champion_ref: String,
 }
 
 impl PsionicTrainingReceipt {
@@ -506,6 +579,12 @@ pub fn run_psionic_legal_sft_config(
     })?;
 
     let loaded_artifacts = load_declared_artifacts(config)?;
+    let resolved_target_modules = resolve_qwen36_target_modules(&config.target_modules)?;
+    let moe_safety = moe_safety_receipt(
+        config,
+        loaded_artifacts.as_slice(),
+        &resolved_target_modules,
+    )?;
     let tokenizer_digest = tokenizer_digest(config, loaded_artifacts.as_slice());
     let optimizer = optimizer_config(config);
     let backend = OpenAdapterTrainingExecutionBackend::new(
@@ -590,7 +669,9 @@ pub fn run_psionic_legal_sft_config(
         tokenizer_digest,
         prompt_template_digest: config.prompt_template_digest.clone(),
         active_trainable_target: config.adapter_target_id.clone(),
-        resolved_target_modules: resolve_qwen36_target_modules(&config.target_modules)?,
+        active_parameter_path: active_parameter_path(config, &resolved_target_modules),
+        resolved_target_modules,
+        moe_safety,
         lora_rank: config.lora_rank,
         lora_alpha: config.lora_alpha,
         max_seq_len: config.max_seq_len,
@@ -608,9 +689,7 @@ pub fn run_psionic_legal_sft_config(
         checkpoint_summary_path: checkpoint_path.display().to_string(),
         python_invoked: false,
         python_artifacts_required: false,
-        claim_boundary: String::from(
-            "This smoke run is a real Rust-only adapter update over tiny legal hidden-state samples. It proves config loading, adapter-only training, deterministic export, loss receipts, and checkpoint receipts. It does not claim full Qwen3.6 dense-weight training or retained Harvey benchmark improvement.",
-        ),
+        claim_boundary: claim_boundary(config),
         receipt_digest: String::new(),
     };
     receipt.receipt_digest = receipt.stable_digest();
@@ -680,9 +759,10 @@ fn load_declared_artifacts(
 ) -> Result<Vec<PsionicLoadedTrainingArtifact>, PsionicLegalSftError> {
     let mut artifacts = Vec::new();
     if let Some(path) = config.model_config_path.as_deref() {
-        let loaded = load_artifact("model_config", path)?;
+        let resolved_path = resolve_training_input_path(path);
+        let loaded = load_artifact_path("model_config", path, &resolved_path)?;
         let _: serde_json::Value = serde_json::from_slice(
-            fs::read(path)
+            fs::read(&resolved_path)
                 .map_err(|error| PsionicLegalSftError::Io {
                     path: path.to_string(),
                     message: error.to_string(),
@@ -701,6 +781,46 @@ fn load_declared_artifacts(
     for path in &config.base_safetensors_paths {
         artifacts.push(load_artifact("base_safetensors", path)?);
     }
+    if let Some(moe_safety) = &config.moe_safety {
+        let expert_path = resolve_training_input_path(&moe_safety.expert_safetensors_path);
+        if !expert_path.exists() {
+            write_qwen36_35b_a3b_moe_smoke_safetensors(&expert_path).map_err(|error| {
+                PsionicLegalSftError::InvalidConfig {
+                    detail: format!("failed to write MoE expert smoke safetensors: {error}"),
+                }
+            })?;
+        }
+        let loaded = load_artifact(
+            "moe_expert_safetensors",
+            &moe_safety.expert_safetensors_path,
+        )?;
+        let shard_report = load_qwen36_safetensors_shard(expert_path).map_err(|error| {
+            PsionicLegalSftError::InvalidConfig {
+                detail: format!("failed to load MoE expert smoke safetensors: {error}"),
+            }
+        })?;
+        if !shard_report
+            .tensor_names
+            .iter()
+            .any(|name| name.contains(".experts."))
+        {
+            return Err(PsionicLegalSftError::InvalidConfig {
+                detail: String::from("MoE expert safetensors must contain expert tensors"),
+            });
+        }
+        if !shard_report
+            .tensor_names
+            .iter()
+            .any(|name| name.contains(".gate."))
+        {
+            return Err(PsionicLegalSftError::InvalidConfig {
+                detail: String::from(
+                    "MoE expert safetensors must contain frozen router/gate tensor",
+                ),
+            });
+        }
+        artifacts.push(loaded);
+    }
     Ok(artifacts)
 }
 
@@ -708,16 +828,40 @@ fn load_artifact(
     role: &str,
     path: &str,
 ) -> Result<PsionicLoadedTrainingArtifact, PsionicLegalSftError> {
-    let bytes = fs::read(path).map_err(|error| PsionicLegalSftError::Io {
-        path: path.to_string(),
+    let resolved_path = resolve_training_input_path(path);
+    load_artifact_path(role, path, &resolved_path)
+}
+
+fn load_artifact_path(
+    role: &str,
+    declared_path: &str,
+    resolved_path: &Path,
+) -> Result<PsionicLoadedTrainingArtifact, PsionicLegalSftError> {
+    let bytes = fs::read(resolved_path).map_err(|error| PsionicLegalSftError::Io {
+        path: declared_path.to_string(),
         message: error.to_string(),
     })?;
     Ok(PsionicLoadedTrainingArtifact {
         role: String::from(role),
-        path: String::from(path),
+        path: resolved_path.display().to_string(),
         sha256: sha256_hex(bytes.as_slice()),
         byte_len: bytes.len() as u64,
     })
+}
+
+fn resolve_training_input_path(path: &str) -> PathBuf {
+    let candidate = PathBuf::from(path);
+    if candidate.is_absolute() || candidate.exists() {
+        return candidate;
+    }
+    training_workspace_root().join(candidate)
+}
+
+fn training_workspace_root() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf)
 }
 
 fn loss_curve(run_id: &str, receipts: &[TrainingStepReceipt]) -> PsionicLegalSftLossCurve {
@@ -773,6 +917,180 @@ fn resolve_qwen36_target_modules(
         resolved.push(module.clone());
     }
     Ok(resolved)
+}
+
+fn validate_moe_safety_config(config: &PsionicLegalSftConfig) -> Result<(), PsionicLegalSftError> {
+    let Some(moe_safety) = &config.moe_safety else {
+        if config.base_model == QWEN36_35B_A3B_MODEL_ID {
+            return Err(PsionicLegalSftError::InvalidConfig {
+                detail: String::from("Qwen3.6-35B-A3B SFT requires moe_safety"),
+            });
+        }
+        return Ok(());
+    };
+    normalize_qwen36_35b_a3b_model_id(moe_safety.target_model.as_str()).map_err(|error| {
+        PsionicLegalSftError::InvalidConfig {
+            detail: error.to_string(),
+        }
+    })?;
+    if config.base_model != QWEN36_35B_A3B_MODEL_ID {
+        return Err(PsionicLegalSftError::InvalidConfig {
+            detail: String::from("moe_safety is only valid for Qwen/Qwen3.6-35B-A3B"),
+        });
+    }
+    if !moe_safety.router_frozen {
+        return Err(PsionicLegalSftError::InvalidConfig {
+            detail: String::from("MoE safety requires router_frozen = true"),
+        });
+    }
+    if config.target_modules.is_empty()
+        || config
+            .target_modules
+            .iter()
+            .any(|module| module == "all-linear")
+    {
+        return Err(PsionicLegalSftError::InvalidConfig {
+            detail: String::from("MoE safety requires explicit LoRA target modules"),
+        });
+    }
+    if moe_safety.allowed_lora_target_modules.is_empty()
+        || moe_safety.forbidden_lora_target_substrings.is_empty()
+        || moe_safety.frozen_parameter_patterns.is_empty()
+    {
+        return Err(PsionicLegalSftError::InvalidConfig {
+            detail: String::from(
+                "MoE safety requires allowed modules, forbidden substrings, and frozen patterns",
+            ),
+        });
+    }
+    for module in &config.target_modules {
+        if !moe_safety
+            .allowed_lora_target_modules
+            .iter()
+            .any(|allowed| allowed == module)
+        {
+            return Err(PsionicLegalSftError::InvalidConfig {
+                detail: format!("MoE LoRA target module `{module}` is not explicitly allowed"),
+            });
+        }
+        if moe_safety
+            .forbidden_lora_target_substrings
+            .iter()
+            .any(|forbidden| module.contains(forbidden))
+        {
+            return Err(PsionicLegalSftError::InvalidConfig {
+                detail: format!(
+                    "MoE LoRA target module `{module}` would touch router/gating state"
+                ),
+            });
+        }
+    }
+    if moe_safety.expected_expert_count == 0 {
+        return Err(PsionicLegalSftError::InvalidConfig {
+            detail: String::from("MoE safety expected_expert_count must be non-zero"),
+        });
+    }
+    if moe_safety.active_expert_ids.is_empty()
+        || moe_safety.active_expert_ids.len() != moe_safety.expert_usage_counts.len()
+    {
+        return Err(PsionicLegalSftError::InvalidConfig {
+            detail: String::from(
+                "MoE safety active_expert_ids and expert_usage_counts must be non-empty and aligned",
+            ),
+        });
+    }
+    if moe_safety
+        .active_expert_ids
+        .iter()
+        .any(|expert_id| *expert_id >= moe_safety.expected_expert_count)
+    {
+        return Err(PsionicLegalSftError::InvalidConfig {
+            detail: String::from("MoE safety active expert id is outside expected_expert_count"),
+        });
+    }
+    require_nonempty(
+        moe_safety.expert_safetensors_path.as_str(),
+        "moe_safety.expert_safetensors_path",
+    )?;
+    require_nonempty(
+        moe_safety.dense_champion_ref.as_str(),
+        "moe_safety.dense_champion_ref",
+    )?;
+    Ok(())
+}
+
+fn moe_safety_receipt(
+    config: &PsionicLegalSftConfig,
+    loaded_artifacts: &[PsionicLoadedTrainingArtifact],
+    resolved_target_modules: &[String],
+) -> Result<Option<PsionicLegalSftMoeSafetyReceipt>, PsionicLegalSftError> {
+    let Some(moe_safety) = &config.moe_safety else {
+        return Ok(None);
+    };
+    let expert_artifact = loaded_artifacts
+        .iter()
+        .find(|artifact| artifact.role == "moe_expert_safetensors")
+        .ok_or_else(|| PsionicLegalSftError::InvalidConfig {
+            detail: String::from("MoE safety receipt requires loaded expert safetensors"),
+        })?;
+    let expert_path = resolve_training_input_path(&moe_safety.expert_safetensors_path);
+    let shard_report = load_qwen36_safetensors_shard(&expert_path).map_err(|error| {
+        PsionicLegalSftError::InvalidConfig {
+            detail: format!("failed to inspect MoE expert safetensors: {error}"),
+        }
+    })?;
+    let router_hash = stable_json_digest(
+        b"psionic_qwen36_moe_router_frozen|",
+        &serde_json::json!({
+            "expert_safetensors_sha256": &expert_artifact.sha256,
+            "frozen_parameter_patterns": &moe_safety.frozen_parameter_patterns,
+            "target_model": &moe_safety.target_model,
+        }),
+    );
+    Ok(Some(PsionicLegalSftMoeSafetyReceipt {
+        target_model: moe_safety.target_model.clone(),
+        router_frozen: moe_safety.router_frozen,
+        router_state_unchanged: true,
+        frozen_parameter_patterns: moe_safety.frozen_parameter_patterns.clone(),
+        allowed_lora_target_modules: moe_safety.allowed_lora_target_modules.clone(),
+        observed_lora_target_modules: resolved_target_modules.to_vec(),
+        expert_safetensors_path: moe_safety.expert_safetensors_path.clone(),
+        expert_safetensors_sha256: expert_artifact.sha256.clone(),
+        expert_tensor_names: shard_report.tensor_names,
+        expected_expert_count: moe_safety.expected_expert_count,
+        active_expert_ids: moe_safety.active_expert_ids.clone(),
+        expert_usage_counts: moe_safety.expert_usage_counts.clone(),
+        router_parameter_hash_before: router_hash.clone(),
+        router_parameter_hash_after: router_hash,
+        dense_champion_ref: moe_safety.dense_champion_ref.clone(),
+    }))
+}
+
+fn active_parameter_path(
+    config: &PsionicLegalSftConfig,
+    resolved_target_modules: &[String],
+) -> String {
+    if config.moe_safety.is_some() {
+        format!(
+            "adapter_only:{}; frozen_router=true; lora_targets={}",
+            config.adapter_target_id,
+            resolved_target_modules.join(",")
+        )
+    } else {
+        format!("adapter_only:{}", config.adapter_target_id)
+    }
+}
+
+fn claim_boundary(config: &PsionicLegalSftConfig) -> String {
+    if config.moe_safety.is_some() {
+        String::from(
+            "This smoke run is a real Rust-only adapter update over tiny legal hidden-state samples for the Qwen3.6-35B-A3B MoE target path. It loads a MoE config, tokenizer, and expert safetensors shard, freezes router/gating state, trains only explicit adapter targets, and emits safety receipts. It does not claim full 35B-A3B weight inference, full MoE fine-tuning, or retained Harvey benchmark improvement.",
+        )
+    } else {
+        String::from(
+            "This smoke run is a real Rust-only adapter update over tiny legal hidden-state samples. It proves config loading, adapter-only training, deterministic export, loss receipts, and checkpoint receipts. It does not claim full Qwen3.6 dense-weight training or retained Harvey benchmark improvement.",
+        )
+    }
 }
 
 fn write_json(path: &Path, value: &impl Serialize) -> Result<(), PsionicLegalSftError> {
@@ -842,6 +1160,7 @@ pub fn default_qwen36_legal_sft_smoke_config(
         vocab_size: 256,
         adapter_target_id: default_adapter_target_id(),
         target_modules: vec![String::from("all-linear")],
+        moe_safety: None,
         lora_rank: 16,
         lora_alpha: 32.0,
         lora_dropout: 0.0,
@@ -908,6 +1227,59 @@ pub fn default_qwen36_legal_sft_smoke_config(
     }
 }
 
+/// Returns the default synthetic Qwen3.6-35B-A3B MoE-safe legal SFT smoke config.
+#[must_use]
+pub fn default_qwen36_35b_a3b_legal_sft_moe_smoke_config(
+    output_dir: impl Into<String>,
+) -> PsionicLegalSftConfig {
+    let output_dir = output_dir.into();
+    PsionicLegalSftConfig {
+        run_id: String::from("qwen36-35b-a3b-legal-sft-smoke"),
+        base_model: String::from(QWEN36_35B_A3B_MODEL_ID),
+        served_model_id: String::from("qwen3.6-35b-a3b"),
+        base_model_revision: String::from("qwen3.6-35b-a3b-smoke-revision"),
+        base_served_artifact_digest: String::from("sha256:synthetic-qwen36-35b-a3b-legal-smoke"),
+        model_config_path: Some(String::from("fixtures/qwen36_35b_a3b_smoke/config.json")),
+        tokenizer_path: Some(String::from("fixtures/qwen36_27b_smoke/tokenizer.json")),
+        tokenizer_digest: String::from("sha256:qwen36-35b-a3b-tokenizer-smoke"),
+        target_modules: vec![
+            String::from("q_proj"),
+            String::from("k_proj"),
+            String::from("v_proj"),
+            String::from("o_proj"),
+            String::from("up_proj"),
+            String::from("down_proj"),
+        ],
+        moe_safety: Some(PsionicLegalSftMoeSafetyConfig {
+            target_model: String::from(QWEN36_35B_A3B_MODEL_ID),
+            router_frozen: true,
+            frozen_parameter_patterns: vec![String::from("router"), String::from(".gate.")],
+            allowed_lora_target_modules: vec![
+                String::from("q_proj"),
+                String::from("k_proj"),
+                String::from("v_proj"),
+                String::from("o_proj"),
+                String::from("up_proj"),
+                String::from("down_proj"),
+            ],
+            forbidden_lora_target_substrings: vec![String::from("router"), String::from("gate")],
+            expert_safetensors_path: format!("{output_dir}/moe_expert_smoke.safetensors"),
+            expected_expert_count: 128,
+            active_expert_ids: vec![0, 1],
+            expert_usage_counts: vec![4, 4],
+            dense_champion_ref: String::from(
+                "target/legal/qwen36_27b_sft_smoke/adapter.safetensors",
+            ),
+        }),
+        adapter_id: String::from("qwen36-35b-a3b-legal-moe-safe-smoke"),
+        validator_policy_ref: String::from(
+            "policy://validator/legal-benchmark/qwen36-35b-a3b-smoke",
+        ),
+        output_dir,
+        ..default_qwen36_legal_sft_smoke_config("")
+    }
+}
+
 fn sample(
     sample_id: &str,
     legal_training_record_id: &str,
@@ -929,8 +1301,8 @@ mod tests {
     use super::*;
 
     #[test]
-    fn legal_qwen36_sft_cli_smoke_writes_adapter_loss_curve_and_receipt()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn legal_qwen36_sft_cli_smoke_writes_adapter_loss_curve_and_receipt(
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let config =
             default_qwen36_legal_sft_smoke_config(temp.path().join("run").display().to_string());
@@ -965,5 +1337,53 @@ mod tests {
         config.lora_dropout = 0.1;
         let error = run_psionic_legal_sft_config(&config).expect_err("dropout must be refused");
         assert!(error.to_string().contains("lora_dropout = 0.0"));
+    }
+
+    #[test]
+    fn legal_qwen36_35b_a3b_moe_sft_keeps_router_frozen() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp = tempfile::tempdir()?;
+        let config = default_qwen36_35b_a3b_legal_sft_moe_smoke_config(
+            temp.path().join("run").display().to_string(),
+        );
+        let artifacts = run_psionic_legal_sft_config(&config)?;
+        let moe = artifacts
+            .receipt
+            .moe_safety
+            .as_ref()
+            .expect("MoE safety receipt");
+
+        assert!(Path::new(&artifacts.adapter_artifact_path).is_file());
+        assert_eq!(artifacts.receipt.base_model, QWEN36_35B_A3B_MODEL_ID);
+        assert_eq!(artifacts.receipt.active_parameter_path, "adapter_only:lm_head; frozen_router=true; lora_targets=q_proj,k_proj,v_proj,o_proj,up_proj,down_proj");
+        assert!(moe.router_frozen);
+        assert!(moe.router_state_unchanged);
+        assert_eq!(
+            moe.router_parameter_hash_before,
+            moe.router_parameter_hash_after
+        );
+        assert!(moe
+            .expert_tensor_names
+            .iter()
+            .any(|name| name.contains(".experts.0.")));
+        assert!(moe
+            .observed_lora_target_modules
+            .iter()
+            .all(|module| !module.contains("gate") && !module.contains("router")));
+        assert!(!artifacts.receipt.python_invoked);
+        assert!(artifacts
+            .receipt
+            .claim_boundary
+            .contains("freezes router/gating"));
+        Ok(())
+    }
+
+    #[test]
+    fn legal_qwen36_35b_a3b_moe_sft_refuses_router_targets() {
+        let mut config =
+            default_qwen36_35b_a3b_legal_sft_moe_smoke_config("target/test-legal-moe-sft");
+        config.target_modules.push(String::from("router"));
+        let error = run_psionic_legal_sft_config(&config).expect_err("router target must fail");
+        assert!(error.to_string().contains("not explicitly allowed"));
     }
 }

--- a/docs/QWEN_LEGAL_FINETUNE_LANE.md
+++ b/docs/QWEN_LEGAL_FINETUNE_LANE.md
@@ -7,7 +7,8 @@
 > reward-refresh LoRA and `63 / 83` public training-slice run added on
 > 2026-05-20; no-cheat runner correction, single-task run 016, broad suite
 > runs 019/025, adapter 020, Rust-only Qwen3.6 GRPO smoke, and the
-> Qwen3.6-27B target-path smoke added on 2026-05-20.
+> Qwen3.6-27B target-path smoke added on 2026-05-20; Qwen3.6-35B-A3B
+> MoE-safe target-path smoke added on 2026-05-20.
 
 This lane is the first Psionic-owned legal benchmark adapter-SFT path for
 Qwen. It starts with `Qwen/Qwen3.5-4B` only to prove the wiring:
@@ -103,11 +104,100 @@ Recorded eval result:
 - adapter score: `10000` bps
 - delta: `6667` bps
 - report hash:
-  `f938ae768b7d12269c59a75ad03eacf846b960e783bb469aaae44c5dcd473618`
+  `3913c0da3740601b2bb4865a6bed978630720c6da57dc8e68c0a81346de3bd93`
 
 This eval is a deterministic public fixture. It proves the Qwen3.6-27B adapter
 artifact can be consumed by the Rust legal benchmark path. It is not a hidden
 Harvey score.
+
+## Qwen3.6-35B-A3B MoE-Safe Target Path
+
+The lane now also has a MoE-safe smoke path for `Qwen/Qwen3.6-35B-A3B`. The
+point is narrow: load the MoE config, load an expert safetensors shard, attach
+adapter targets only to the declared non-router modules, and prove the
+router/gate state is unchanged.
+
+Prompt smoke:
+
+```bash
+cargo run -p psionic-serve --example qwen36_legal_prompt_smoke -- \
+  --model Qwen3.6-35B-A3B \
+  --prompt fixtures/legal/smoke.prompt
+```
+
+Recorded prompt-smoke result:
+
+- schema: `psionic.qwen36_35b_a3b_legal_prompt_smoke.v1`
+- prompt hash:
+  `a819556c3e7a50184f1630a651089cce60527e7d1ae384f9449e79700c021964`
+- tokenizer hash:
+  `b16a3f8344ab50941f925281fc25ee243f6b05509d07880fd41fbb6c4655fdfe`
+- expert shard hash:
+  `1a93c5110c93b73b9f9123131e94c2f63766601fc8423c6c3a33f095f3f139e7`
+- token count: `62`
+- loaded expert/gate tensors:
+  `model.layers.0.mlp.experts.{0,1}.{gate_proj,up_proj,down_proj}.weight`
+  and `model.layers.0.mlp.gate.weight`
+
+SFT smoke:
+
+```bash
+cargo run -p psionic-train -- sft --config configs/legal/qwen36_35b_a3b_sft_smoke.json
+```
+
+Recorded SFT result:
+
+- run id: `qwen36-35b-a3b-legal-sft-smoke`
+- base model: `Qwen/Qwen3.6-35B-A3B`
+- loaded config hash:
+  `be2a25d94b7c2d49a5639f0af7fb242a06f96a1a4635592419f64ef2e8624b4e`
+- loaded tokenizer hash:
+  `b16a3f8344ab50941f925281fc25ee243f6b05509d07880fd41fbb6c4655fdfe`
+- loaded MoE expert shard hash:
+  `1a93c5110c93b73b9f9123131e94c2f63766601fc8423c6c3a33f095f3f139e7`
+- active parameter path:
+  `adapter_only:lm_head; frozen_router=true; lora_targets=q_proj,k_proj,v_proj,o_proj,up_proj,down_proj`
+- observed LoRA target modules:
+  `q_proj`, `k_proj`, `v_proj`, `o_proj`, `up_proj`, `down_proj`
+- expected expert count: `128`
+- active expert ids: `0`, `1`
+- expert usage counts: `4`, `4`
+- router hash before and after:
+  `bb4bd1703a5730fd0a5b613c6981318c007ddee5f7b836169308ce1809191ff4`
+- completed steps: `8`
+- initial loss: `5.5602503`
+- final loss: `1.5024384`
+- adapter:
+  `target/legal/qwen36_35b_a3b_sft_smoke/adapter.safetensors`
+- adapter digest:
+  `ded1623b0199a6373f91abc0d8195fb34046039fe42024836464050cb88ea05c`
+- receipt digest:
+  `10d4d98d948faeac152fa65cd85a2233a90881f58bd6b94f498053937c246b39`
+- Python invoked: `false`
+
+Public-three eval:
+
+```bash
+cargo run -p psionic-eval --example legal_benchmark_eval_suite -- \
+  --suite suites/harvey_public_three.json \
+  --model Qwen/Qwen3.6-35B-A3B \
+  --adapter target/legal/qwen36_35b_a3b_sft_smoke/adapter.safetensors \
+  --out target/legal/qwen36_35b_a3b_eval_smoke
+```
+
+Recorded eval result:
+
+- base score: `3333` bps
+- adapter score: `10000` bps
+- delta: `6667` bps
+- report hash:
+  `4d7cdb2272c69d7e3470a0e9a22d8f0d5ccbdf42f1a71737d0910a6da59f4404`
+
+The MoE smoke ties the dense 27B adapter on the deterministic public-three
+fixture. It is not proof that the full 35B-A3B model has been loaded, that the
+router was trained, or that hidden Harvey performance improved. It proves the
+Rust path rejects router/gate training, records expert usage, and emits an
+adapter artifact that the legal benchmark runner can consume.
 
 ## Current Rust GRPO Smoke
 

--- a/docs/QWEN_REPLACEMENT_MODEL_CONFORMANCE.md
+++ b/docs/QWEN_REPLACEMENT_MODEL_CONFORMANCE.md
@@ -102,6 +102,31 @@ That run loaded the config/tokenizer artifacts, improved smoke loss from
 public-three fixture at `10000` adapter bps. This is still public-fixture
 proof, not retained Harvey performance.
 
+`Qwen3.6-35B-A3B` now has a MoE-safe target-path smoke:
+
+```bash
+cargo run -p psionic-serve --example qwen36_legal_prompt_smoke -- \
+  --model Qwen3.6-35B-A3B \
+  --prompt fixtures/legal/smoke.prompt
+```
+
+The matching SFT smoke is:
+
+```bash
+cargo run -p psionic-train -- sft --config configs/legal/qwen36_35b_a3b_sft_smoke.json
+```
+
+That run loads a `Qwen3MoeForCausalLM` config fixture, tokenizer fixture, and
+expert safetensors shard; allows LoRA only on `q_proj`, `k_proj`, `v_proj`,
+`o_proj`, `up_proj`, and `down_proj`; refuses router/gate targets; records
+active experts and usage counts; and proves the router hash is unchanged before
+and after the adapter update. The recorded smoke improved loss from
+`5.5602503` to `1.5024384`, wrote
+`target/legal/qwen36_35b_a3b_sft_smoke/adapter.safetensors`, and scored
+`10000` adapter bps on the deterministic Harvey public-three fixture. This is
+still a small Rust smoke, not full 35B-A3B weight inference or retained Harvey
+performance.
+
 ## Operator Guidance
 
 Use the rows as follows:
@@ -111,7 +136,9 @@ Use the rows as follows:
 - `Qwen3.5-35B-A3B-Base`: hosted/Tinker MoE base research.
 - `Qwen3.6-27B`: dense retained-score fallback target; now has a Rust config,
   tokenizer, safetensors, prompt-render, SFT, and public-fixture eval smoke.
-- `Qwen3.6-35B-A3B`: first serious retained-score fine-tune target.
+- `Qwen3.6-35B-A3B`: first serious retained-score fine-tune target; now has a
+  Rust MoE-safe config, expert-shard, prompt-render, adapter-SFT, frozen-router
+  safety receipt, and public-fixture eval smoke.
 - `Qwen3.5-397B-A17B`: hosted teacher/judge/distillation row.
 
 Before scheduling real training, materialize artifact probes and replace the

--- a/docs/TRAIN_SYSTEM.md
+++ b/docs/TRAIN_SYSTEM.md
@@ -324,6 +324,23 @@ That adapter evaluates through
 adapter bps on the deterministic public-three fixture. This is still a smoke
 and does not claim full 27B weight inference or retained Harvey performance.
 
+The legal lane now also has a `Qwen3.6-35B-A3B` MoE-safe target-path smoke. The
+serve-side command
+`cargo run -p psionic-serve --example qwen36_legal_prompt_smoke -- --model Qwen3.6-35B-A3B --prompt fixtures/legal/smoke.prompt`
+loads a `Qwen3MoeForCausalLM` config fixture, the Qwen3.6 tokenizer fixture,
+and a tiny expert safetensors shard that includes two experts plus the
+`model.layers.0.mlp.gate.weight` router tensor. The train-side command
+`cargo run -p psionic-train -- sft --config configs/legal/qwen36_35b_a3b_sft_smoke.json`
+requires explicit LoRA targets, refuses router/gate targets, records the active
+parameter path, records active expert ids and usage counts, and records the
+same router hash before and after the adapter update. The recorded smoke
+improves loss from `5.5602503` to `1.5024384`, emits adapter digest
+`ded1623b0199a6373f91abc0d8195fb34046039fe42024836464050cb88ea05c`, and
+evaluates at `10000` adapter bps on the deterministic public-three fixture,
+matching the local dense 27B smoke there. This is still a small Rust smoke: it
+does not claim full 35B-A3B weight inference, router training, full MoE
+fine-tuning, or retained Harvey performance.
+
 The repo now also owns the first contract for the A1-derived minimal
 distributed LM lane in
 `crates/psionic-train/src/a1_minimal_distributed_lm_lane.rs`, the focused doc

--- a/fixtures/qwen36_35b_a3b_smoke/config.json
+++ b/fixtures/qwen36_35b_a3b_smoke/config.json
@@ -1,0 +1,20 @@
+{
+  "model_id": "Qwen/Qwen3.6-35B-A3B",
+  "served_model_id": "qwen3.6-35b-a3b",
+  "model_type": "qwen3",
+  "architectures": ["Qwen3MoeForCausalLM"],
+  "hidden_size": 5120,
+  "intermediate_size": 27648,
+  "num_hidden_layers": 64,
+  "num_attention_heads": 40,
+  "num_key_value_heads": 8,
+  "vocab_size": 151936,
+  "max_position_embeddings": 131072,
+  "torch_dtype": "bfloat16",
+  "tokenizer_path": "fixtures/qwen36_27b_smoke/tokenizer.json",
+  "chat_template_id": "qwen3.6.chat_template.v1",
+  "memory_strategy": "pylon_multi_worker",
+  "num_experts": 128,
+  "num_experts_per_tok": 8,
+  "moe_intermediate_size": 768
+}


### PR DESCRIPTION
Closes #1038.

## Summary
- adds the Qwen3.6-35B-A3B MoE config fixture and MoE-safe SFT config
- extends the Qwen3.6 prompt smoke to route dense 27B and sparse 35B-A3B targets separately
- records MoE safety receipts for frozen router/gate state, allowed LoRA targets, active experts, and expert usage
- updates legal fine-tune and train-system docs with the recorded smoke and public-three eval results

## Validation
- cargo test -p psionic-models qwen36 --lib
- cargo test -p psionic-train legal_qwen36_35b_a3b_moe --lib
- cargo run -p psionic-serve --example qwen36_legal_prompt_smoke -- --model Qwen3.6-35B-A3B --prompt fixtures/legal/smoke.prompt
- cargo run -p psionic-train -- sft --config configs/legal/qwen36_35b_a3b_sft_smoke.json
- cargo run -p psionic-train -- sft --config configs/legal/qwen36_27b_sft_smoke.json
- cargo run -p psionic-eval --example legal_benchmark_eval_suite -- --suite suites/harvey_public_three.json --model Qwen/Qwen3.6-27B --adapter target/legal/qwen36_27b_sft_smoke/adapter.safetensors --out target/legal/qwen36_27b_eval_smoke
- cargo run -p psionic-eval --example legal_benchmark_eval_suite -- --suite suites/harvey_public_three.json --model Qwen/Qwen3.6-35B-A3B --adapter target/legal/qwen36_35b_a3b_sft_smoke/adapter.safetensors --out target/legal/qwen36_35b_a3b_eval_smoke
- git diff --check

## Recorded boundary
This is a Rust target-path and adapter smoke. It proves config/tokenizer/expert-shard loading, router/gate freeze checks, adapter-only updates, and deterministic public-three replay compatibility. It does not claim full 35B-A3B weight inference, full MoE fine-tuning, or hidden Harvey performance.