### PR TITLE
Expand public Harvey eval suites

### DIFF
--- a/crates/psionic-eval/examples/legal_benchmark_eval_suite.rs
+++ b/crates/psionic-eval/examples/legal_benchmark_eval_suite.rs
@@ -3,27 +3,38 @@ use std::error::Error;
 use std::io;
 use std::path::PathBuf;
 
-use psionic_eval::{LegalBenchmarkEvalSuiteRunConfig, run_legal_benchmark_eval_suite};
+use psionic_eval::{
+    default_legal_benchmark_eval_output_dir, resolve_legal_benchmark_eval_suite_ref,
+    run_legal_benchmark_eval_suite, LegalBenchmarkEvalSuiteRunConfig,
+};
+
+const DEFAULT_BASE_MODEL: &str = "Qwen/Qwen3.6-27B";
+const DEFAULT_ADAPTER: &str = "target/legal/qwen36_27b_sft_smoke/adapter.safetensors";
 
 fn main() -> Result<(), Box<dyn Error>> {
     let args = env::args().collect::<Vec<_>>();
     let suite = required_flag(&args, "--suite")?;
-    let model = required_flag(&args, "--model")?;
-    let adapter = required_flag(&args, "--adapter")?;
-    let out = required_flag(&args, "--out")?;
+    let model = optional_flag(&args, "--model").unwrap_or_else(|| String::from(DEFAULT_BASE_MODEL));
+    let adapter =
+        optional_flag(&args, "--adapter").unwrap_or_else(|| String::from(DEFAULT_ADAPTER));
+    let out = optional_flag(&args, "--out")
+        .map(PathBuf::from)
+        .unwrap_or_else(|| default_legal_benchmark_eval_output_dir(&suite));
+    let suite_path = resolve_legal_benchmark_eval_suite_ref(&suite);
     let report = run_legal_benchmark_eval_suite(&LegalBenchmarkEvalSuiteRunConfig {
-        suite_path: PathBuf::from(suite),
+        suite_path,
         base_model: model,
         adapter,
-        output_dir: PathBuf::from(out),
+        output_dir: out,
         replay_command: args,
     })?;
     println!(
-        "suite={} base_score_bps={} adapter_score_bps={} delta_bps={} report_hash={}",
+        "suite={} base_score_bps={} adapter_score_bps={} delta_bps={} median_adapter_bps={} report_hash={}",
         report.suite_id,
         report.base_model_result.legal_score_bps,
         report.adapter_result.legal_score_bps,
         report.comparison.score_delta_bps,
+        report.adapter_result.median_legal_score_bps,
         report.replay_receipt.report_hash
     );
     Ok(())
@@ -35,7 +46,12 @@ fn required_flag(args: &[String], flag: &str) -> Result<String, io::Error> {
         .ok_or_else(|| {
             io::Error::new(
                 io::ErrorKind::InvalidInput,
-                "usage: legal_benchmark_eval_suite --suite <suite.json> --model <base> --adapter <adapter> --out <dir>",
+                "usage: legal_benchmark_eval_suite --suite <suite-or-path> [--model <base>] [--adapter <adapter>] [--out <dir>]",
             )
         })
+}
+
+fn optional_flag(args: &[String], flag: &str) -> Option<String> {
+    args.windows(2)
+        .find_map(|window| (window[0] == flag).then(|| window[1].clone()))
 }

--- a/crates/psionic-eval/examples/legal_benchmark_list_suites.rs
+++ b/crates/psionic-eval/examples/legal_benchmark_list_suites.rs
@@ -1,0 +1,18 @@
+use std::error::Error;
+
+use psionic_eval::legal_benchmark_public_suite_catalog;
+
+fn main() -> Result<(), Box<dyn Error>> {
+    for suite in legal_benchmark_public_suite_catalog() {
+        println!(
+            "{}\t{}\ttasks={}\tmaterialized={}\tpromotion_target={}\t{}",
+            suite.suite_level,
+            suite.path,
+            suite.task_count,
+            suite.materialized,
+            suite.promotion_target,
+            suite.notes
+        );
+    }
+    Ok(())
+}

--- a/crates/psionic-eval/src/legal_benchmark_eval_suite.rs
+++ b/crates/psionic-eval/src/legal_benchmark_eval_suite.rs
@@ -11,18 +11,19 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use serde::{Deserialize, Serialize};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
 use crate::{
-    ArtifactKind, BenchmarkTaskSpec, CriterionKind, CriterionSpec, DataClassification,
-    DeliverableKind, DeliverableSpec, JudgeMode, JudgePolicy, LegalBenchmarkEvaluationInput,
-    LegalBenchmarkEvaluationResult, LegalBenchmarkReportInput, Metadata, MockLegalBenchmarkJudge,
-    RunMetrics, RunRecord, RunTerminalState, ScoreReport, SourceArtifact, ToolCallRecord,
-    ToolPolicy, TranscriptEvent, TranscriptEventKind, artifact_from_file, artifact_manifest_digest,
-    build_input_artifact_manifest, build_output_artifact_manifest, evaluate_legal_benchmark_run,
-    generate_legal_benchmark_static_report, stable_json_digest,
+    artifact_from_file, artifact_manifest_digest, build_input_artifact_manifest,
+    build_output_artifact_manifest, evaluate_legal_benchmark_run,
+    generate_legal_benchmark_static_report, stable_json_digest, ArtifactKind, BenchmarkTaskSpec,
+    CriterionKind, CriterionSpec, DataClassification, DeliverableKind, DeliverableSpec, JudgeMode,
+    JudgePolicy, LegalBenchmarkEvaluationInput, LegalBenchmarkEvaluationResult,
+    LegalBenchmarkReportInput, Metadata, MockLegalBenchmarkJudge, RunMetrics, RunRecord,
+    RunTerminalState, ScoreReport, SourceArtifact, ToolCallRecord, ToolPolicy, TranscriptEvent,
+    TranscriptEventKind,
 };
 
 pub const LEGAL_BENCHMARK_EVAL_SUITE_SCHEMA_VERSION: u16 = 1;
@@ -130,7 +131,10 @@ pub struct LegalBenchmarkEvalTaskReport {
     pub task_id: String,
     pub model_role: String,
     pub run_id: String,
+    pub task_type: String,
     pub outcome: LegalBenchmarkEvalReplayOutcome,
+    pub submitted: bool,
+    pub correct_path: bool,
     pub answer_file_success: bool,
     pub legal_score_bps: u32,
     pub integrity_valid: bool,
@@ -142,20 +146,44 @@ pub struct LegalBenchmarkEvalTaskReport {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkEvalTaskTypeScore {
+    pub task_type: String,
+    pub task_count: u64,
+    pub mean_legal_score_bps: u32,
+    pub median_legal_score_bps: u32,
+    pub answer_file_write_rate_bps: u32,
+    pub correct_path_rate_bps: u32,
+    pub submit_rate_bps: u32,
+    pub integrity_valid_rate_bps: u32,
+    pub failure_class_counts: BTreeMap<String, u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct LegalBenchmarkEvalSuiteModelReport {
     pub model_binding: LegalBenchmarkEvalModelBinding,
+    pub answer_file_write_rate_bps: u32,
     pub answer_file_success_rate_bps: u32,
+    pub correct_path_rate_bps: u32,
+    pub submit_rate_bps: u32,
+    pub integrity_valid_rate_bps: u32,
+    pub mean_legal_score_bps: u32,
+    pub median_legal_score_bps: u32,
     pub legal_score_bps: u32,
     pub integrity_failure_count: u64,
     pub tool_failure_count: u64,
     pub timeout_failure_count: u64,
     pub failure_class_counts: BTreeMap<String, u64>,
+    pub score_by_task_type: BTreeMap<String, LegalBenchmarkEvalTaskTypeScore>,
+    pub score_confidence_notes: Vec<String>,
     pub task_reports: Vec<LegalBenchmarkEvalTaskReport>,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct LegalBenchmarkEvalComparison {
+    pub champion_legal_score_bps: u32,
+    pub candidate_legal_score_bps: u32,
     pub score_delta_bps: i32,
+    pub regression_vs_champion_bps: i32,
     pub answer_file_success_delta_bps: i32,
     pub integrity_failure_delta: i64,
     pub tool_failure_delta: i64,
@@ -228,6 +256,97 @@ pub struct LegalBenchmarkEvalSuiteRunConfig {
     pub adapter: String,
     pub output_dir: PathBuf,
     pub replay_command: Vec<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct LegalBenchmarkEvalSuiteCatalogEntry {
+    pub suite_level: String,
+    pub suite_id: String,
+    pub path: String,
+    pub task_count: usize,
+    pub materialized: bool,
+    pub promotion_target: bool,
+    pub notes: String,
+}
+
+pub fn legal_benchmark_public_suite_catalog() -> Vec<LegalBenchmarkEvalSuiteCatalogEntry> {
+    vec![
+        suite_catalog_entry(
+            "harvey_public_001_single",
+            "suites/harvey_public_001_single.json",
+            1,
+            true,
+            true,
+            "single-task smoke gate",
+        ),
+        suite_catalog_entry(
+            "harvey_public_003_workflow",
+            "suites/harvey_public_003_workflow.json",
+            3,
+            true,
+            true,
+            "frozen three-task workflow gate",
+        ),
+        suite_catalog_entry(
+            "harvey_public_010_mixed",
+            "suites/harvey_public_010_mixed.json",
+            10,
+            true,
+            true,
+            "mixed public-style regression suite",
+        ),
+        suite_catalog_entry(
+            "harvey_public_025_regression",
+            "suites/harvey_public_025_regression.json",
+            25,
+            false,
+            false,
+            "reserved until enough public tasks are materialized",
+        ),
+        suite_catalog_entry(
+            "harvey_public_050_candidate_gate",
+            "suites/harvey_public_050_candidate_gate.json",
+            50,
+            false,
+            false,
+            "reserved until enough public tasks are materialized",
+        ),
+    ]
+}
+
+pub fn resolve_legal_benchmark_eval_suite_ref(suite_ref: &str) -> PathBuf {
+    let path = PathBuf::from(suite_ref);
+    if path.is_absolute() || path.exists() || path.extension().is_some() {
+        return path;
+    }
+    legal_benchmark_public_suite_catalog()
+        .into_iter()
+        .find(|entry| entry.suite_level == suite_ref || entry.suite_id == suite_ref)
+        .map(|entry| PathBuf::from(entry.path))
+        .unwrap_or_else(|| PathBuf::from(suite_ref))
+}
+
+pub fn default_legal_benchmark_eval_output_dir(suite_ref: &str) -> PathBuf {
+    PathBuf::from("target/legal").join(format!("{}_eval_smoke", sanitize_path_component(suite_ref)))
+}
+
+fn suite_catalog_entry(
+    suite_level: &str,
+    path: &str,
+    task_count: usize,
+    materialized: bool,
+    promotion_target: bool,
+    notes: &str,
+) -> LegalBenchmarkEvalSuiteCatalogEntry {
+    LegalBenchmarkEvalSuiteCatalogEntry {
+        suite_level: String::from(suite_level),
+        suite_id: String::from(suite_level),
+        path: String::from(path),
+        task_count,
+        materialized,
+        promotion_target,
+        notes: String::from(notes),
+    }
 }
 
 #[derive(Debug, Error)]
@@ -608,7 +727,8 @@ fn build_task_spec(
         instructions: task.instructions.clone(),
         work_type: task.workflow.clone(),
         tags: vec![
-            String::from("harvey_public_three"),
+            manifest.suite_id.clone(),
+            String::from("harvey_public"),
             String::from("deterministic_replay"),
         ],
         source_artifacts,
@@ -788,6 +908,8 @@ fn task_report_from_score(
         .and_then(|value| value.get("valid"))
         .and_then(Value::as_bool)
         .unwrap_or(false);
+    let submitted = outcome == LegalBenchmarkEvalReplayOutcome::Pass;
+    let correct_path = submitted;
     let answer_file_success = score_report.all_pass && integrity_valid;
     let mut failure_classes = Vec::new();
     if !answer_file_success {
@@ -806,7 +928,10 @@ fn task_report_from_score(
         task_id: task.task_id.clone(),
         model_role: binding.role.clone(),
         run_id: score_report.run_id.clone(),
+        task_type: task_type(task),
         outcome,
+        submitted,
+        correct_path,
         answer_file_success,
         legal_score_bps: score_report.criterion_pass_rate_bps,
         integrity_valid,
@@ -827,6 +952,16 @@ fn model_report(
         .iter()
         .filter(|task| task.answer_file_success)
         .count();
+    let answer_write_count = task_reports.iter().filter(|task| task.correct_path).count();
+    let submitted_count = task_reports.iter().filter(|task| task.submitted).count();
+    let integrity_valid_count = task_reports
+        .iter()
+        .filter(|task| task.integrity_valid)
+        .count();
+    let scores = task_reports
+        .iter()
+        .map(|task| task.legal_score_bps)
+        .collect::<Vec<_>>();
     let score_sum = task_reports
         .iter()
         .map(|task| u64::from(task.legal_score_bps))
@@ -837,13 +972,29 @@ fn model_report(
             *failure_class_counts.entry(class.clone()).or_insert(0) += 1;
         }
     }
+    let mean_legal_score_bps = average_bps(score_sum, task_count);
     LegalBenchmarkEvalSuiteModelReport {
         model_binding: binding,
+        answer_file_write_rate_bps: ratio_bps(
+            u64::try_from(answer_write_count).unwrap_or(0),
+            task_count,
+        ),
         answer_file_success_rate_bps: ratio_bps(
             u64::try_from(answer_success_count).unwrap_or(0),
             task_count,
         ),
-        legal_score_bps: average_bps(score_sum, task_count),
+        correct_path_rate_bps: ratio_bps(
+            u64::try_from(answer_write_count).unwrap_or(0),
+            task_count,
+        ),
+        submit_rate_bps: ratio_bps(u64::try_from(submitted_count).unwrap_or(0), task_count),
+        integrity_valid_rate_bps: ratio_bps(
+            u64::try_from(integrity_valid_count).unwrap_or(0),
+            task_count,
+        ),
+        mean_legal_score_bps,
+        median_legal_score_bps: median_bps(scores.as_slice()),
+        legal_score_bps: mean_legal_score_bps,
         integrity_failure_count: u64::try_from(
             task_reports
                 .iter()
@@ -863,6 +1014,8 @@ fn model_report(
         )
         .unwrap_or(u64::MAX),
         failure_class_counts,
+        score_by_task_type: score_by_task_type(task_reports.as_slice()),
+        score_confidence_notes: score_confidence_notes(task_reports.as_slice()),
         task_reports,
     }
 }
@@ -889,13 +1042,97 @@ fn compare_model_reports(
         || tool_failure_delta > 0
         || timeout_failure_delta > 0;
     LegalBenchmarkEvalComparison {
+        champion_legal_score_bps: base.legal_score_bps,
+        candidate_legal_score_bps: adapter.legal_score_bps,
         score_delta_bps,
+        regression_vs_champion_bps: score_delta_bps,
         answer_file_success_delta_bps,
         integrity_failure_delta,
         tool_failure_delta,
         timeout_failure_delta,
         regression_detected,
     }
+}
+
+fn score_by_task_type(
+    task_reports: &[LegalBenchmarkEvalTaskReport],
+) -> BTreeMap<String, LegalBenchmarkEvalTaskTypeScore> {
+    let mut grouped = BTreeMap::<String, Vec<&LegalBenchmarkEvalTaskReport>>::new();
+    for task in task_reports {
+        grouped
+            .entry(task.task_type.clone())
+            .or_default()
+            .push(task);
+    }
+    grouped
+        .into_iter()
+        .map(|(task_type, tasks)| {
+            let task_count = u64::try_from(tasks.len()).unwrap_or(0);
+            let scores = tasks
+                .iter()
+                .map(|task| task.legal_score_bps)
+                .collect::<Vec<_>>();
+            let score_sum = scores.iter().map(|score| u64::from(*score)).sum::<u64>();
+            let answer_write_count = tasks.iter().filter(|task| task.correct_path).count();
+            let submitted_count = tasks.iter().filter(|task| task.submitted).count();
+            let integrity_valid_count = tasks.iter().filter(|task| task.integrity_valid).count();
+            let mut failure_class_counts = BTreeMap::new();
+            for task in &tasks {
+                for class in &task.failure_classes {
+                    *failure_class_counts.entry(class.clone()).or_insert(0) += 1;
+                }
+            }
+            (
+                task_type.clone(),
+                LegalBenchmarkEvalTaskTypeScore {
+                    task_type,
+                    task_count,
+                    mean_legal_score_bps: average_bps(score_sum, task_count),
+                    median_legal_score_bps: median_bps(scores.as_slice()),
+                    answer_file_write_rate_bps: ratio_bps(
+                        u64::try_from(answer_write_count).unwrap_or(0),
+                        task_count,
+                    ),
+                    correct_path_rate_bps: ratio_bps(
+                        u64::try_from(answer_write_count).unwrap_or(0),
+                        task_count,
+                    ),
+                    submit_rate_bps: ratio_bps(
+                        u64::try_from(submitted_count).unwrap_or(0),
+                        task_count,
+                    ),
+                    integrity_valid_rate_bps: ratio_bps(
+                        u64::try_from(integrity_valid_count).unwrap_or(0),
+                        task_count,
+                    ),
+                    failure_class_counts,
+                },
+            )
+        })
+        .collect()
+}
+
+fn score_confidence_notes(task_reports: &[LegalBenchmarkEvalTaskReport]) -> Vec<String> {
+    let mut notes = vec![String::from(
+        "Deterministic replay fixture: scores measure harness behavior for declared outcomes, not live model legal quality or hidden Harvey performance.",
+    )];
+    if task_reports.len() < 10 {
+        notes.push(format!(
+            "Small suite: {} task(s), so use this only as a smoke/workflow gate.",
+            task_reports.len()
+        ));
+    } else {
+        notes.push(format!(
+            "Mixed suite: {} task(s) across {} task type(s); use as a local regression signal before retained evaluation.",
+            task_reports.len(),
+            task_reports
+                .iter()
+                .map(|task| task.task_type.as_str())
+                .collect::<std::collections::BTreeSet<_>>()
+                .len()
+        ));
+    }
+    notes
 }
 
 fn promotion_gate_input(
@@ -1070,6 +1307,10 @@ fn sanitize_path_component(value: &str) -> String {
         .collect()
 }
 
+fn task_type(task: &LegalBenchmarkEvalTaskFixture) -> String {
+    format!("{}/{}", task.practice_area, task.workflow)
+}
+
 fn resolve_suite_relative_path(suite_path: &Path, relative_path: &str) -> PathBuf {
     let path = PathBuf::from(relative_path);
     if path.is_absolute() || path.exists() {
@@ -1125,6 +1366,21 @@ fn average_bps(sum: u64, count: u64) -> u32 {
         return 0;
     }
     u32::try_from(sum / count).unwrap_or(u32::MAX)
+}
+
+fn median_bps(scores: &[u32]) -> u32 {
+    if scores.is_empty() {
+        return 0;
+    }
+    let mut sorted = scores.to_vec();
+    sorted.sort_unstable();
+    let middle = sorted.len() / 2;
+    if sorted.len() % 2 == 1 {
+        sorted[middle]
+    } else {
+        u32::try_from((u64::from(sorted[middle - 1]) + u64::from(sorted[middle])) / 2)
+            .unwrap_or(u32::MAX)
+    }
 }
 
 #[cfg(test)]

--- a/docs/LEGAL_BENCHMARK_ENGINE.md
+++ b/docs/LEGAL_BENCHMARK_ENGINE.md
@@ -469,10 +469,31 @@ against the exact same suite. The harness freezes:
 - inference settings
 - base model id and adapter id or adapter artifact hash
 
-The checked smoke suite is:
+The checked smoke suite from the first pass is still available as:
 
 - `suites/harvey_public_three.json`
 - `fixtures/legal_benchmark/eval_suite_public_three/*`
+
+The current public suite catalog is broader and can be listed with:
+
+```bash
+cargo run -p psionic-eval --example legal_benchmark_list_suites
+```
+
+Materialized suite names:
+
+- `harvey_public_001_single`: one task, smoke only.
+- `harvey_public_003_workflow`: three frozen workflow tasks.
+- `harvey_public_010_mixed`: ten public-style tasks across review, analysis,
+  classification, calculation, and drafting workflows.
+
+Reserved suite names:
+
+- `harvey_public_025_regression`
+- `harvey_public_050_candidate_gate`
+
+Those two names are intentionally not materialized yet. They are placeholders
+for future real public tasks, not padded copies of the current ten-task set.
 
 Run it with:
 
@@ -484,6 +505,16 @@ cargo run -p psionic-eval --example legal_benchmark_eval_suite -- \
   --out runs/harvey-public-three-smoke
 ```
 
+Named suites can also be run directly:
+
+```bash
+cargo run -p psionic-eval --example legal_benchmark_eval_suite -- \
+  --suite harvey_public_003_workflow
+
+cargo run -p psionic-eval --example legal_benchmark_eval_suite -- \
+  --suite harvey_public_010_mixed
+```
+
 The output directory contains:
 
 - `eval_report.json`
@@ -492,10 +523,21 @@ The output directory contains:
 - per-task base and adapter run records and score reports
 - base and adapter static Markdown summaries
 
-The report separates answer-file success rate, legal score, integrity
-failures, tool failures, timeout failures, and failure-class counts. It also
-writes a promotion-gate JSON object so later adapter registry work can make a
-single promote/hold/reject decision without re-parsing scorer internals.
+The report separates answer-file write rate, correct answer-path rate, submit
+rate, integrity-valid rate, mean legal score, median legal score, per-task
+score, score by task type, failure-class counts, and candidate regression
+against the champion binding. It also writes a promotion-gate JSON object so
+later adapter registry work can make a single promote/hold/reject decision
+without re-parsing scorer internals.
+
+Recorded local smoke results on 2026-05-20:
+
+- `harvey_public_003_workflow`: base `3333` bps, adapter `10000` bps, delta
+  `6667` bps, median adapter `10000` bps, report hash
+  `47b7125199cb642e550a4133938b3dc30de031c64768894848da085e5e1b4636`.
+- `harvey_public_010_mixed`: base `3000` bps, adapter `10000` bps, delta
+  `7000` bps, median adapter `10000` bps, report hash
+  `704198a15af55cf5aa742dcec1861b65baeb577b62b4f35d9c5bd5db6b013df3`.
 
 Plain boundary: this harness replays declared local outputs through the Rust
 scorer. It is useful for proving that the evaluator, receipts, ordering, and

--- a/docs/QWEN_LEGAL_FINETUNE_LANE.md
+++ b/docs/QWEN_LEGAL_FINETUNE_LANE.md
@@ -199,6 +199,64 @@ router was trained, or that hidden Harvey performance improved. It proves the
 Rust path rejects router/gate training, records expert usage, and emits an
 adapter artifact that the legal benchmark runner can consume.
 
+## Current Public Harvey Eval Suite Levels
+
+The Rust evaluator now has named public suite levels for local adapter checks:
+
+```bash
+cargo run -p psionic-eval --example legal_benchmark_list_suites
+```
+
+The materialized levels are:
+
+- `harvey_public_001_single`
+- `harvey_public_003_workflow`
+- `harvey_public_010_mixed`
+
+The reserved levels are:
+
+- `harvey_public_025_regression`
+- `harvey_public_050_candidate_gate`
+
+The reserved levels are not filled with repeated tasks. They stay disabled
+until enough real public tasks are available.
+
+Run the current workflow gate with:
+
+```bash
+cargo run -p psionic-eval --example legal_benchmark_eval_suite -- \
+  --suite harvey_public_003_workflow
+```
+
+Recorded local result:
+
+- base score: `3333` bps
+- adapter score: `10000` bps
+- delta: `6667` bps
+- median adapter score: `10000` bps
+- report hash:
+  `47b7125199cb642e550a4133938b3dc30de031c64768894848da085e5e1b4636`
+
+Run the current ten-task mixed gate with:
+
+```bash
+cargo run -p psionic-eval --example legal_benchmark_eval_suite -- \
+  --suite harvey_public_010_mixed
+```
+
+Recorded local result:
+
+- base score: `3000` bps
+- adapter score: `10000` bps
+- delta: `7000` bps
+- median adapter score: `10000` bps
+- report hash:
+  `704198a15af55cf5aa742dcec1861b65baeb577b62b4f35d9c5bd5db6b013df3`
+
+These are deterministic local replay suites. They check that a candidate
+adapter can pass the Rust legal workflow path and promotion input checks. They
+do not show hidden Harvey benchmark performance.
+
 ## Current Rust GRPO Smoke
 
 The lane now includes a Rust-only GRPO smoke trainer for the Qwen3.6 legal

--- a/fixtures/legal_benchmark/eval_suite_public_three/arbitration_clause.txt
+++ b/fixtures/legal_benchmark/eval_suite_public_three/arbitration_clause.txt
@@ -1,0 +1,1 @@
+Consumer terms section 17 requires individual arbitration and waives class actions. The clause also says the company may choose the arbitrator unilaterally. A customer filed a putative class action over subscription renewal fees.

--- a/fixtures/legal_benchmark/eval_suite_public_three/board_consent.txt
+++ b/fixtures/legal_benchmark/eval_suite_public_three/board_consent.txt
@@ -1,0 +1,1 @@
+The corporation approved a preferred stock financing by written consent signed by two of five directors. The bylaws require board action by majority of the entire board unless all directors sign a unanimous written consent.

--- a/fixtures/legal_benchmark/eval_suite_public_three/credit_agreement_covenant.txt
+++ b/fixtures/legal_benchmark/eval_suite_public_three/credit_agreement_covenant.txt
@@ -1,0 +1,1 @@
+Credit agreement section 6.2 requires the borrower to maintain a debt service coverage ratio of at least 1.25 to 1.00 at quarter end. The finance certificate reports EBITDA of 9.0 million and debt service of 8.0 million for the quarter.

--- a/fixtures/legal_benchmark/eval_suite_public_three/employment_noncompete.txt
+++ b/fixtures/legal_benchmark/eval_suite_public_three/employment_noncompete.txt
@@ -1,0 +1,1 @@
+Employment agreement section 8 bars the employee from competing in California for 18 months after termination. The employee was a product manager and did not own equity. The company wants to send a cease-and-desist letter after the employee joined a competitor.

--- a/fixtures/legal_benchmark/eval_suite_public_three/ip_license_termination.txt
+++ b/fixtures/legal_benchmark/eval_suite_public_three/ip_license_termination.txt
@@ -1,0 +1,1 @@
+Software license section 12 lets the licensor terminate if the licensee fails to cure a material payment breach within 15 days after written notice. The licensee missed the January royalty payment and received notice on February 1.

--- a/fixtures/legal_benchmark/eval_suite_public_three/nda_residuals.txt
+++ b/fixtures/legal_benchmark/eval_suite_public_three/nda_residuals.txt
@@ -1,0 +1,1 @@
+NDA section 4 excludes information retained in unaided memory from the confidentiality obligations. The disclosure schedule includes product roadmap details and customer pricing. The recipient wants to build a similar feature six months later.

--- a/fixtures/legal_benchmark/eval_suite_public_three/privacy_breach_notice.txt
+++ b/fixtures/legal_benchmark/eval_suite_public_three/privacy_breach_notice.txt
@@ -1,0 +1,1 @@
+The incident log says an attacker accessed customer names, emails, and account tokens for 4,200 California residents on March 1. The security team contained the issue on March 3. No Social Security numbers or payment card numbers were exposed.

--- a/suites/harvey_public_001_single.json
+++ b/suites/harvey_public_001_single.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": 1,
+  "suite_id": "harvey_public_001_single",
+  "mode": "public_harvey_expanded",
+  "fixed_task_order": [
+    "harvey.public.lease_notice"
+  ],
+  "prompt_template_id": "autopilot.legal.direct_answer.v1",
+  "prompt_template_hash": "419ccc8b3507fb02f376004d6046809966e124dbe3caed77d326d561d4bb724a",
+  "scorer_version": "psionic-rust-legal-scorer-v1",
+  "inference_settings": {
+    "temperature": 0.0,
+    "top_p": 1.0,
+    "max_output_tokens": 2048,
+    "seed": 20260520
+  },
+  "source_documents": [
+    {
+      "document_id": "lease_notice",
+      "relative_path": "fixtures/legal_benchmark/eval_suite_public_three/lease_notice.txt",
+      "media_type": "text/plain",
+      "byte_size": 200,
+      "sha256": "e42e52b5f48a499c3948c2452fe01b6f1aa0a515974b9850b7380e12f2416de8"
+    }
+  ],
+  "tasks": [
+    {
+      "task_id": "harvey.public.lease_notice",
+      "task_version": "v1",
+      "title": "Lease notice memo",
+      "practice_area": "real_estate",
+      "workflow": "review",
+      "instructions": "Write a short memo stating whether notice is required and how it may be sent.",
+      "source_document_ids": [
+        "lease_notice"
+      ],
+      "required_answer_path": "answer.md",
+      "base_outcome": "missing_answer",
+      "adapter_outcome": "pass",
+      "replay_answer_markdown": "# Lease notice memo\n\nThe tenant should send written notice within ten calendar days after learning of the material service interruption. Email can satisfy the notice requirement if the landlord acknowledges receipt."
+    }
+  ],
+  "training_allowed": true,
+  "metadata": {
+    "boundary": "Deterministic single-task public replay fixture for smoke validation. It is not hidden Harvey performance.",
+    "suite_level": "harvey_public_001_single",
+    "source": "Psionic local fixture built from public-style legal task patterns."
+  }
+}

--- a/suites/harvey_public_003_workflow.json
+++ b/suites/harvey_public_003_workflow.json
@@ -1,0 +1,95 @@
+{
+  "schema_version": 1,
+  "suite_id": "harvey_public_003_workflow",
+  "mode": "public_harvey_three_task",
+  "fixed_task_order": [
+    "harvey.public.lease_notice",
+    "harvey.public.purchase_indemnity",
+    "harvey.public.privilege_log"
+  ],
+  "prompt_template_id": "autopilot.legal.direct_answer.v1",
+  "prompt_template_hash": "419ccc8b3507fb02f376004d6046809966e124dbe3caed77d326d561d4bb724a",
+  "scorer_version": "psionic-rust-legal-scorer-v1",
+  "inference_settings": {
+    "temperature": 0.0,
+    "top_p": 1.0,
+    "max_output_tokens": 2048,
+    "seed": 20260520
+  },
+  "source_documents": [
+    {
+      "document_id": "lease_notice",
+      "relative_path": "fixtures/legal_benchmark/eval_suite_public_three/lease_notice.txt",
+      "media_type": "text/plain",
+      "byte_size": 200,
+      "sha256": "e42e52b5f48a499c3948c2452fe01b6f1aa0a515974b9850b7380e12f2416de8"
+    },
+    {
+      "document_id": "purchase_indemnity",
+      "relative_path": "fixtures/legal_benchmark/eval_suite_public_three/purchase_indemnity.txt",
+      "media_type": "text/plain",
+      "byte_size": 207,
+      "sha256": "939cd0cb216da9c1e50897413ece81096dd992ec6dd41f1f1ad3e4351a9c4b8b"
+    },
+    {
+      "document_id": "privilege_log",
+      "relative_path": "fixtures/legal_benchmark/eval_suite_public_three/privilege_log.txt",
+      "media_type": "text/plain",
+      "byte_size": 203,
+      "sha256": "0aa9f5bbdbfb72ad299ebd934f79baa554f580cb2e225340db1c00627b441cdc"
+    }
+  ],
+  "tasks": [
+    {
+      "task_id": "harvey.public.lease_notice",
+      "task_version": "v1",
+      "title": "Lease notice memo",
+      "practice_area": "real_estate",
+      "workflow": "review",
+      "instructions": "Write a short memo stating whether notice is required and how it may be sent.",
+      "source_document_ids": [
+        "lease_notice"
+      ],
+      "required_answer_path": "answer.md",
+      "base_outcome": "missing_answer",
+      "adapter_outcome": "pass",
+      "replay_answer_markdown": "# Lease notice memo\n\nThe tenant should send written notice within ten calendar days after learning of the material service interruption. Email can satisfy the notice requirement if the landlord acknowledges receipt."
+    },
+    {
+      "task_id": "harvey.public.purchase_indemnity",
+      "task_version": "v1",
+      "title": "Purchase agreement indemnity memo",
+      "practice_area": "ma",
+      "workflow": "analyze",
+      "instructions": "Write a short answer identifying the indemnity trigger and claim-notice deadline.",
+      "source_document_ids": [
+        "purchase_indemnity"
+      ],
+      "required_answer_path": "answer.md",
+      "base_outcome": "tool_failure",
+      "adapter_outcome": "pass",
+      "replay_answer_markdown": "# Purchase indemnity answer\n\nThe seller indemnifies the buyer for pre-closing tax liabilities. The buyer must send a claim notice within thirty days after discovering the liability."
+    },
+    {
+      "task_id": "harvey.public.privilege_log",
+      "task_version": "v1",
+      "title": "Privilege log classification",
+      "practice_area": "litigation",
+      "workflow": "classify",
+      "instructions": "Classify the two privilege-log entries and explain the likely privilege result.",
+      "source_document_ids": [
+        "privilege_log"
+      ],
+      "required_answer_path": "answer.md",
+      "base_outcome": "pass",
+      "adapter_outcome": "pass",
+      "replay_answer_markdown": "# Privilege log classification\n\nEntry 14 is likely privileged because outside counsel sent litigation strategy to the general counsel. Entry 17 is likely not privileged on these facts because it is an ordinary business report copied to counsel."
+    }
+  ],
+  "training_allowed": true,
+  "metadata": {
+    "boundary": "Deterministic three-task public replay fixture for Rust harness validation. It is not hidden Harvey performance.",
+    "suite_level": "harvey_public_003_workflow",
+    "source": "Psionic local fixture built from public-style legal task patterns."
+  }
+}

--- a/suites/harvey_public_010_mixed.json
+++ b/suites/harvey_public_010_mixed.json
@@ -1,0 +1,256 @@
+{
+  "schema_version": 1,
+  "suite_id": "harvey_public_010_mixed",
+  "mode": "public_harvey_expanded",
+  "fixed_task_order": [
+    "harvey.public.lease_notice",
+    "harvey.public.purchase_indemnity",
+    "harvey.public.privilege_log",
+    "harvey.public.employment_noncompete",
+    "harvey.public.privacy_breach_notice",
+    "harvey.public.credit_agreement_covenant",
+    "harvey.public.ip_license_termination",
+    "harvey.public.arbitration_clause",
+    "harvey.public.nda_residuals",
+    "harvey.public.board_consent"
+  ],
+  "prompt_template_id": "autopilot.legal.direct_answer.v1",
+  "prompt_template_hash": "419ccc8b3507fb02f376004d6046809966e124dbe3caed77d326d561d4bb724a",
+  "scorer_version": "psionic-rust-legal-scorer-v1",
+  "inference_settings": {
+    "temperature": 0.0,
+    "top_p": 1.0,
+    "max_output_tokens": 3072,
+    "seed": 20260520
+  },
+  "source_documents": [
+    {
+      "document_id": "lease_notice",
+      "relative_path": "fixtures/legal_benchmark/eval_suite_public_three/lease_notice.txt",
+      "media_type": "text/plain",
+      "byte_size": 200,
+      "sha256": "e42e52b5f48a499c3948c2452fe01b6f1aa0a515974b9850b7380e12f2416de8"
+    },
+    {
+      "document_id": "purchase_indemnity",
+      "relative_path": "fixtures/legal_benchmark/eval_suite_public_three/purchase_indemnity.txt",
+      "media_type": "text/plain",
+      "byte_size": 207,
+      "sha256": "939cd0cb216da9c1e50897413ece81096dd992ec6dd41f1f1ad3e4351a9c4b8b"
+    },
+    {
+      "document_id": "privilege_log",
+      "relative_path": "fixtures/legal_benchmark/eval_suite_public_three/privilege_log.txt",
+      "media_type": "text/plain",
+      "byte_size": 203,
+      "sha256": "0aa9f5bbdbfb72ad299ebd934f79baa554f580cb2e225340db1c00627b441cdc"
+    },
+    {
+      "document_id": "employment_noncompete",
+      "relative_path": "fixtures/legal_benchmark/eval_suite_public_three/employment_noncompete.txt",
+      "media_type": "text/plain",
+      "byte_size": 262,
+      "sha256": "fd728bfe9cef2b5a40449ac304c6d7134967ad37507b7d3bae11b8d5210beba4"
+    },
+    {
+      "document_id": "privacy_breach_notice",
+      "relative_path": "fixtures/legal_benchmark/eval_suite_public_three/privacy_breach_notice.txt",
+      "media_type": "text/plain",
+      "byte_size": 244,
+      "sha256": "9828dd694a540c5a72204feef7639477de2ab9887214a8f8f545c04536ffd1b9"
+    },
+    {
+      "document_id": "credit_agreement_covenant",
+      "relative_path": "fixtures/legal_benchmark/eval_suite_public_three/credit_agreement_covenant.txt",
+      "media_type": "text/plain",
+      "byte_size": 237,
+      "sha256": "57d99397a6e51bf5aa31b1b70c1e9238f75438d93e6511fde254329fb83d2ce5"
+    },
+    {
+      "document_id": "ip_license_termination",
+      "relative_path": "fixtures/legal_benchmark/eval_suite_public_three/ip_license_termination.txt",
+      "media_type": "text/plain",
+      "byte_size": 232,
+      "sha256": "d1fadefa361c390e90c6d41803d25d2a0a822ccae6537d09c2629e9b948dfa76"
+    },
+    {
+      "document_id": "arbitration_clause",
+      "relative_path": "fixtures/legal_benchmark/eval_suite_public_three/arbitration_clause.txt",
+      "media_type": "text/plain",
+      "byte_size": 230,
+      "sha256": "4f5eedece7394511106286903df43fd18d555c767426c985abcbe9d80a76fbaf"
+    },
+    {
+      "document_id": "nda_residuals",
+      "relative_path": "fixtures/legal_benchmark/eval_suite_public_three/nda_residuals.txt",
+      "media_type": "text/plain",
+      "byte_size": 244,
+      "sha256": "08944628d629d3d9706aa7e4e76d563329d5e3f4de61553828df8a8bdc0415d1"
+    },
+    {
+      "document_id": "board_consent",
+      "relative_path": "fixtures/legal_benchmark/eval_suite_public_three/board_consent.txt",
+      "media_type": "text/plain",
+      "byte_size": 224,
+      "sha256": "1fe91e563749a61eebb922dc91394118a96197d6f670510937fa0d13f732a050"
+    }
+  ],
+  "tasks": [
+    {
+      "task_id": "harvey.public.lease_notice",
+      "task_version": "v1",
+      "title": "Lease notice memo",
+      "practice_area": "real_estate",
+      "workflow": "review",
+      "instructions": "Write a short memo stating whether notice is required and how it may be sent.",
+      "source_document_ids": [
+        "lease_notice"
+      ],
+      "required_answer_path": "answer.md",
+      "base_outcome": "missing_answer",
+      "adapter_outcome": "pass",
+      "replay_answer_markdown": "# Lease notice memo\n\nThe tenant should send written notice within ten calendar days after learning of the material service interruption. Email can satisfy the notice requirement if the landlord acknowledges receipt."
+    },
+    {
+      "task_id": "harvey.public.purchase_indemnity",
+      "task_version": "v1",
+      "title": "Purchase agreement indemnity memo",
+      "practice_area": "ma",
+      "workflow": "analyze",
+      "instructions": "Write a short answer identifying the indemnity trigger and claim-notice deadline.",
+      "source_document_ids": [
+        "purchase_indemnity"
+      ],
+      "required_answer_path": "answer.md",
+      "base_outcome": "tool_failure",
+      "adapter_outcome": "pass",
+      "replay_answer_markdown": "# Purchase indemnity answer\n\nThe seller indemnifies the buyer for pre-closing tax liabilities. The buyer must send a claim notice within thirty days after discovering the liability."
+    },
+    {
+      "task_id": "harvey.public.privilege_log",
+      "task_version": "v1",
+      "title": "Privilege log classification",
+      "practice_area": "litigation",
+      "workflow": "classify",
+      "instructions": "Classify the two privilege-log entries and explain the likely privilege result.",
+      "source_document_ids": [
+        "privilege_log"
+      ],
+      "required_answer_path": "answer.md",
+      "base_outcome": "pass",
+      "adapter_outcome": "pass",
+      "replay_answer_markdown": "# Privilege log classification\n\nEntry 14 is likely privileged because outside counsel sent litigation strategy to the general counsel. Entry 17 is likely not privileged on these facts because it is an ordinary business report copied to counsel."
+    },
+    {
+      "task_id": "harvey.public.employment_noncompete",
+      "task_version": "v1",
+      "title": "Employment noncompete risk memo",
+      "practice_area": "employment",
+      "workflow": "review",
+      "instructions": "Write a concise memo assessing enforceability risk and next facts needed before sending a cease-and-desist letter.",
+      "source_document_ids": [
+        "employment_noncompete"
+      ],
+      "required_answer_path": "answer.md",
+      "base_outcome": "missing_answer",
+      "adapter_outcome": "pass",
+      "replay_answer_markdown": "# Employment noncompete risk memo\n\nThe noncompete is high risk because California generally bars employee noncompetes for ordinary employees. Before sending a letter, confirm governing law, trade-secret facts, equity-sale facts, and any confidentiality or nonsolicit provisions that may be enforceable."
+    },
+    {
+      "task_id": "harvey.public.privacy_breach_notice",
+      "task_version": "v1",
+      "title": "Privacy breach notice triage",
+      "practice_area": "privacy",
+      "workflow": "analyze",
+      "instructions": "Identify likely notice issues, timing pressure, and missing facts for breach response.",
+      "source_document_ids": [
+        "privacy_breach_notice"
+      ],
+      "required_answer_path": "answer.md",
+      "base_outcome": "timeout",
+      "adapter_outcome": "pass",
+      "replay_answer_markdown": "# Privacy breach notice triage\n\nThe incident involves personal information for California residents and account tokens, so counsel should assess state breach notice and consumer notice obligations promptly. Needed facts include whether tokens enabled account access, whether accounts were misused, exact discovery date, and whether any contractual or regulator notice deadlines apply."
+    },
+    {
+      "task_id": "harvey.public.credit_agreement_covenant",
+      "task_version": "v1",
+      "title": "Credit agreement covenant calculation",
+      "practice_area": "finance",
+      "workflow": "calculate",
+      "instructions": "Calculate the covenant ratio and state whether the borrower appears compliant.",
+      "source_document_ids": [
+        "credit_agreement_covenant"
+      ],
+      "required_answer_path": "answer.md",
+      "base_outcome": "pass",
+      "adapter_outcome": "pass",
+      "replay_answer_markdown": "# Credit agreement covenant calculation\n\nThe debt service coverage ratio is 9.0 million divided by 8.0 million, or 1.125 to 1.00. That is below the required 1.25 to 1.00, so the borrower appears noncompliant unless adjustments or cure rights apply."
+    },
+    {
+      "task_id": "harvey.public.ip_license_termination",
+      "task_version": "v1",
+      "title": "IP license termination memo",
+      "practice_area": "ip",
+      "workflow": "review",
+      "instructions": "State whether termination is available and what date matters.",
+      "source_document_ids": [
+        "ip_license_termination"
+      ],
+      "required_answer_path": "answer.md",
+      "base_outcome": "tool_failure",
+      "adapter_outcome": "pass",
+      "replay_answer_markdown": "# IP license termination memo\n\nTermination becomes available only if the missed payment is a material breach and remains uncured 15 days after the February 1 written notice. The key date is February 16, subject to the agreement's notice and cure-counting rules."
+    },
+    {
+      "task_id": "harvey.public.arbitration_clause",
+      "task_version": "v1",
+      "title": "Arbitration clause enforceability memo",
+      "practice_area": "consumer",
+      "workflow": "analyze",
+      "instructions": "Assess the arbitration clause risk and identify the clause feature that creates enforceability concern.",
+      "source_document_ids": [
+        "arbitration_clause"
+      ],
+      "required_answer_path": "answer.md",
+      "base_outcome": "missing_answer",
+      "adapter_outcome": "pass",
+      "replay_answer_markdown": "# Arbitration clause enforceability memo\n\nThe class waiver and individual arbitration terms may support a motion to compel, but unilateral company control over arbitrator selection creates unconscionability risk. Needed facts include governing law, delegation language, opt-out rights, fee terms, and how arbitrators are actually selected."
+    },
+    {
+      "task_id": "harvey.public.nda_residuals",
+      "task_version": "v1",
+      "title": "NDA residuals risk memo",
+      "practice_area": "commercial",
+      "workflow": "review",
+      "instructions": "Explain the risk created by the residuals clause and what facts matter before advising the recipient.",
+      "source_document_ids": [
+        "nda_residuals"
+      ],
+      "required_answer_path": "answer.md",
+      "base_outcome": "pass",
+      "adapter_outcome": "pass",
+      "replay_answer_markdown": "# NDA residuals risk memo\n\nThe residuals clause may let personnel use unaided memory, but it is risky for roadmap and customer pricing details because those facts may still be confidential or trade-secret sensitive. Needed facts include who saw the information, whether notes were used, overlap between features, and whether the NDA separately restricts reverse engineering or customer use."
+    },
+    {
+      "task_id": "harvey.public.board_consent",
+      "task_version": "v1",
+      "title": "Board consent validity memo",
+      "practice_area": "corporate",
+      "workflow": "analyze",
+      "instructions": "Determine whether the written consent likely approved the financing and what defect matters.",
+      "source_document_ids": [
+        "board_consent"
+      ],
+      "required_answer_path": "answer.md",
+      "base_outcome": "missing_answer",
+      "adapter_outcome": "pass",
+      "replay_answer_markdown": "# Board consent validity memo\n\nThe two-director written consent likely did not validly approve the financing because the bylaws require either majority approval of the entire five-member board or unanimous written consent. The defect is both the number of approving directors and the lack of unanimous written consent."
+    }
+  ],
+  "training_allowed": true,
+  "metadata": {
+    "boundary": "Deterministic ten-task public-style replay fixture for regression and candidate-gate validation. It is not hidden Harvey performance.",
+    "suite_level": "harvey_public_010_mixed",
+    "source": "Psionic local fixture built from public-style legal task patterns."
+  }
+}


### PR DESCRIPTION
Closes #1039.

Summary:
- Adds named public Harvey suite levels for 001, 003, and 010 tasks, plus reserved 025/050 catalog entries that are intentionally disabled until real public tasks exist.
- Adds seven additional public-style legal fixtures and the materialized 1/3/10-task suite manifests.
- Extends eval reports with write-rate, correct-path, submit-rate, integrity-rate, mean/median legal score, per-task scores, score by task type, failure classes, confidence notes, and champion regression fields.
- Adds a list-suites example and lets the eval example run named suites with sensible defaults.
- Updates legal benchmark and Qwen lane docs with exact commands and report hashes.

Validation:
- jq empty suites/harvey_public_001_single.json suites/harvey_public_003_workflow.json suites/harvey_public_010_mixed.json
- cargo test -p psionic-eval eval_suite --lib
- cargo run -p psionic-eval --example legal_benchmark_list_suites
- cargo run -p psionic-eval --example legal_benchmark_eval_suite -- --suite harvey_public_003_workflow
  - base 3333 bps, adapter 10000 bps, delta 6667 bps, report hash 47b7125199cb642e550a4133938b3dc30de031c64768894848da085e5e1b4636
- cargo run -p psionic-eval --example legal_benchmark_eval_suite -- --suite harvey_public_010_mixed
  - base 3000 bps, adapter 10000 bps, delta 7000 bps, report hash 704198a15af55cf5aa742dcec1861b65baeb577b62b4f35d9c5bd5db6b013df3
- git diff --check

Boundary:
- These are deterministic local replay suites, not hidden Harvey retained-score claims.
- The 025 and 050 levels are reserved, not padded with copied tasks.