### PR TITLE
Add sandbox profile enforcement receipt evidence

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ promotion decision that refuses held-out regressions or failed operator review.
 - Blueprint program integration boundary: Blueprint owns business-facing
   Program records; Psionic supplies execution and optimization evidence.
 - Legal benchmark engine: [docs/LEGAL_BENCHMARK_ENGINE.md](docs/LEGAL_BENCHMARK_ENGINE.md)
+- Sandbox profile enforcement: [docs/SANDBOX_PROFILE_ENFORCEMENT.md](docs/SANDBOX_PROFILE_ENFORCEMENT.md)
 - Forge-facing eval pack publication: [docs/PSION_FORGE_EVAL_PACK_MANIFESTS.md](docs/PSION_FORGE_EVAL_PACK_MANIFESTS.md)
 - Hermes user guide: [docs/hermes/README.md](docs/hermes/README.md)
 - Training system: [docs/TRAIN_SYSTEM.md](docs/TRAIN_SYSTEM.md)

--- a/crates/psionic-sandbox/src/execution.rs
+++ b/crates/psionic-sandbox/src/execution.rs
@@ -86,6 +86,14 @@ pub struct ProviderSandboxDeliveryEvidence {
     pub evidence_id: String,
     pub profile_id: String,
     pub profile_digest: String,
+    pub declared_network_policy: String,
+    pub requested_network_policy: String,
+    pub declared_filesystem_policy: String,
+    pub requested_filesystem_policy: String,
+    pub declared_timeout_limit_s: u64,
+    pub requested_timeout_s: u64,
+    pub artifact_output_policy: String,
+    pub secret_policy: String,
     pub runtime_environment_digest: String,
     pub job_input_digest: String,
     pub entrypoint_digest: String,
@@ -731,6 +739,14 @@ fn build_result(
         ),
         profile_id: profile.profile_id.clone(),
         profile_digest: profile.profile_digest.clone(),
+        declared_network_policy: profile.network_mode.clone(),
+        requested_network_policy: request.network_request.clone(),
+        declared_filesystem_policy: profile.filesystem_mode.clone(),
+        requested_filesystem_policy: request.filesystem_request.clone(),
+        declared_timeout_limit_s: profile.timeout_limit_s,
+        requested_timeout_s: request.timeout_request_s,
+        artifact_output_policy: profile.artifact_output_mode.clone(),
+        secret_policy: profile.secrets_mode.clone(),
         runtime_environment_digest: runtime_environment_digest(profile),
         job_input_digest: completed.job_input_digest.clone(),
         entrypoint_digest: completed.entrypoint_digest.clone(),
@@ -878,6 +894,13 @@ fn job_input_digest(request: &ProviderSandboxJobRequest) -> String {
     for output in &request.expected_outputs {
         encoded.extend_from_slice(output.as_bytes());
     }
+    encoded.extend_from_slice(request.timeout_request_s.to_string().as_bytes());
+    encoded.extend_from_slice(request.network_request.as_bytes());
+    encoded.extend_from_slice(request.filesystem_request.as_bytes());
+    for env in &request.environment {
+        encoded.extend_from_slice(env.key.as_bytes());
+        encoded.extend_from_slice(env.value.as_bytes());
+    }
     sha256_prefixed(encoded.as_slice())
 }
 
@@ -936,9 +959,9 @@ mod tests {
     use psionic_core::{PsionicRefusalCode, PsionicRefusalScope};
 
     use super::{
-        ProviderSandboxEntrypointType, ProviderSandboxExecutionControls,
+        execute_sandbox_job, ProviderSandboxEntrypointType, ProviderSandboxExecutionControls,
         ProviderSandboxExecutionState, ProviderSandboxJobRequest, ProviderSandboxResourceRequest,
-        ProviderSandboxTerminationReason, execute_sandbox_job,
+        ProviderSandboxTerminationReason,
     };
     use crate::{
         ProviderSandboxExecutionClass, ProviderSandboxProfile, ProviderSandboxRuntimeKind,
@@ -1066,8 +1089,8 @@ mod tests {
     }
 
     #[test]
-    fn local_subprocess_success_emits_receipt_and_artifacts()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn local_subprocess_success_emits_receipt_and_artifacts(
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let runtime = fake_binary(
             temp.path(),
@@ -1103,12 +1126,40 @@ mod tests {
             result.receipt.evidence.payout_reference.as_deref() == Some("payment-1"),
             "sandbox subprocess should retain payout reference",
         )?;
+        ensure(
+            result.receipt.evidence.profile_digest == "sha256:profile",
+            "sandbox receipt should cite the profile digest",
+        )?;
+        ensure(
+            result.receipt.evidence.declared_network_policy == "host_inherit",
+            "sandbox receipt should cite declared network policy",
+        )?;
+        ensure(
+            result.receipt.evidence.requested_network_policy == "host_inherit",
+            "sandbox receipt should cite requested network policy",
+        )?;
+        ensure(
+            result.receipt.evidence.declared_filesystem_policy == "host_inherit",
+            "sandbox receipt should cite declared filesystem policy",
+        )?;
+        ensure(
+            result.receipt.evidence.requested_filesystem_policy == "host_inherit",
+            "sandbox receipt should cite requested filesystem policy",
+        )?;
+        ensure(
+            result.receipt.evidence.declared_timeout_limit_s == 5,
+            "sandbox receipt should cite declared timeout limit",
+        )?;
+        ensure(
+            result.receipt.evidence.requested_timeout_s == 2,
+            "sandbox receipt should cite requested timeout",
+        )?;
         Ok(())
     }
 
     #[test]
-    fn node_runner_executes_inline_payload_and_emits_artifact()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn node_runner_executes_inline_payload_and_emits_artifact(
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let runtime = fake_binary(
             temp.path(),
@@ -1143,8 +1194,8 @@ mod tests {
     }
 
     #[test]
-    fn container_adapter_passes_workspace_and_network_policy()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn container_adapter_passes_workspace_and_network_policy(
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let runtime = fake_binary(
             temp.path(),
@@ -1255,8 +1306,110 @@ mod tests {
     }
 
     #[test]
-    fn policy_rejection_receipt_maps_into_refusal_taxonomy()
-    -> Result<(), Box<dyn std::error::Error>> {
+    fn network_policy_mismatch_is_rejected_and_receipted() -> Result<(), Box<dyn std::error::Error>>
+    {
+        let temp = tempfile::tempdir()?;
+        let runtime = fake_binary(
+            temp.path(),
+            "runtime",
+            "#!/bin/sh\nscript=\"$1\"\nshift\n/bin/sh \"$script\" \"$@\"\n",
+        )?;
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace)?;
+        let profile =
+            subprocess_profile(runtime.as_path(), ProviderSandboxExecutionClass::PythonExec);
+        let mut request = request(&workspace, ProviderSandboxExecutionClass::PythonExec);
+        request.network_request = "none".to_string();
+
+        let result = execute_sandbox_job(
+            &profile,
+            &request,
+            &ProviderSandboxExecutionControls::default(),
+        );
+
+        ensure(
+            result.receipt.final_state == ProviderSandboxExecutionState::Rejected,
+            "sandbox network policy mismatch should be rejected",
+        )?;
+        ensure(
+            result.receipt.evidence.termination_reason
+                == ProviderSandboxTerminationReason::PolicyRejected,
+            "sandbox network mismatch should be a policy rejection",
+        )?;
+        ensure(
+            result.receipt.evidence.declared_network_policy == "host_inherit",
+            "network mismatch receipt should cite declared policy",
+        )?;
+        ensure(
+            result.receipt.evidence.requested_network_policy == "none",
+            "network mismatch receipt should cite requested policy",
+        )?;
+        ensure(
+            result
+                .receipt
+                .evidence
+                .policy_detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("network request")),
+            "network mismatch should preserve refusal detail",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn filesystem_policy_mismatch_is_rejected_and_receipted(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let temp = tempfile::tempdir()?;
+        let runtime = fake_binary(
+            temp.path(),
+            "runtime",
+            "#!/bin/sh\nscript=\"$1\"\nshift\n/bin/sh \"$script\" \"$@\"\n",
+        )?;
+        let workspace = temp.path().join("workspace");
+        std::fs::create_dir_all(&workspace)?;
+        let profile =
+            subprocess_profile(runtime.as_path(), ProviderSandboxExecutionClass::PythonExec);
+        let mut request = request(&workspace, ProviderSandboxExecutionClass::PythonExec);
+        request.filesystem_request = "workspace_only".to_string();
+
+        let result = execute_sandbox_job(
+            &profile,
+            &request,
+            &ProviderSandboxExecutionControls::default(),
+        );
+
+        ensure(
+            result.receipt.final_state == ProviderSandboxExecutionState::Rejected,
+            "sandbox filesystem policy mismatch should be rejected",
+        )?;
+        ensure(
+            result.receipt.evidence.termination_reason
+                == ProviderSandboxTerminationReason::PolicyRejected,
+            "sandbox filesystem mismatch should be a policy rejection",
+        )?;
+        ensure(
+            result.receipt.evidence.declared_filesystem_policy == "host_inherit",
+            "filesystem mismatch receipt should cite declared policy",
+        )?;
+        ensure(
+            result.receipt.evidence.requested_filesystem_policy == "workspace_only",
+            "filesystem mismatch receipt should cite requested policy",
+        )?;
+        ensure(
+            result
+                .receipt
+                .evidence
+                .policy_detail
+                .as_deref()
+                .is_some_and(|detail| detail.contains("filesystem request")),
+            "filesystem mismatch should preserve refusal detail",
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn policy_rejection_receipt_maps_into_refusal_taxonomy(
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let temp = tempfile::tempdir()?;
         let runtime = fake_binary(
             temp.path(),

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3010,7 +3010,7 @@ training subsystems.
 | `ModelIoCompatibilityContract` | `psionic-train` | machine-readable boundary contract for supported and unsupported checkpoint/model portability surfaces | `implemented` |
 | `AdapterArtifactIdentity` | `psionic-adapters` | stable identity for one adapter artifact | `implemented` |
 | `AdapterPackageManifest` | `psionic-adapters` | package manifest for adapter bytes tied to datastream | `implemented` |
-| `ProviderSandboxExecutionReceipt` | `psionic-sandbox` | receipt for one bounded sandbox run | `implemented` |
+| `ProviderSandboxExecutionReceipt` | `psionic-sandbox` | receipt for one bounded sandbox run, including profile digest plus declared/requested network, filesystem, timeout, artifact, and secret policy evidence | `implemented` |
 | `TrainingRun` | `psionic-train` | root identity, participant graph, and lifecycle state for one training program | `implemented_early` |
 | `TrainingWindow` | `psionic-train` | one synchronized contribution or trainer interval with contributor-set and transition state | `implemented_early` |
 | `LiveRlRunStatusArtifact` | `psionic-train` | durable operator-facing run-status artifact for one live RL run | `implemented_early` |

--- a/docs/SANDBOX_PROFILE_ENFORCEMENT.md
+++ b/docs/SANDBOX_PROFILE_ENFORCEMENT.md
@@ -1,0 +1,49 @@
+# Sandbox Profile Enforcement
+
+> Status: implemented for `psionic-sandbox` profile-bound local execution and
+> refusal receipts.
+
+`psionic-sandbox` executes bounded jobs only through a declared
+`ProviderSandboxProfile`. The profile is the authority for execution class,
+network policy, filesystem policy, timeout limit, artifact policy, and secret
+policy.
+
+## Enforcement
+
+`execute_sandbox_job` rejects a request before runtime start when:
+
+- the requested execution class does not match the profile;
+- the requested timeout exceeds the profile timeout limit;
+- requested CPU, memory, or disk limits exceed the profile;
+- requested network policy differs from the declared profile policy;
+- requested filesystem policy differs from the declared profile policy;
+- the profile forbids injected environment or secret material;
+- expected output paths escape the workspace.
+
+Policy refusals return `ProviderSandboxExecutionReceipt` with
+`final_state = rejected` and `termination_reason = policy_rejected`.
+
+## Receipt Evidence
+
+Every execution receipt now carries both the declared profile boundary and the
+request boundary:
+
+- `profile_id`
+- `profile_digest`
+- `declared_network_policy`
+- `requested_network_policy`
+- `declared_filesystem_policy`
+- `requested_filesystem_policy`
+- `declared_timeout_limit_s`
+- `requested_timeout_s`
+- `artifact_output_policy`
+- `secret_policy`
+
+This lets schedulers and settlement layers verify that a job ran under the
+declared sandbox profile or was refused before it could escape that profile.
+
+## Boundary
+
+Psionic owns runtime profile enforcement and execution evidence. Higher-level
+assignment admission, workroom policy, user acceptance, and settlement remain
+outside this repo.


### PR DESCRIPTION
## Summary
- Adds declared/requested network, filesystem, timeout, artifact, and secret policy fields to sandbox execution receipts.
- Binds policy fields into the sandbox job input digest.
- Adds tests for network and filesystem policy mismatch refusal receipts.
- Documents the sandbox profile enforcement boundary.

## Verification
- `cargo check -p psionic-sandbox`
- `cargo test -p psionic-sandbox execution::tests -- --test-threads=1`
- `rustfmt --edition 2021 --check crates/psionic-sandbox/src/execution.rs`
- `git diff --check`

Full package note: `cargo test -p psionic-sandbox -- --test-threads=1` still fails in three existing Tassadar committed-truth report tests unrelated to `execution.rs`; no fixture files were modified by the run.

Companion to OpenAgentsInc/cloud#21.
Closes #1088